### PR TITLE
Support all cli options described in the first version of docs (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,24 +73,26 @@ OR you can pass these arguments directly in command line:
 # List of options Save cli
 Most of the options below can be passed to a SAVE via `save.properties` file
 
-// FixMe: add description and short names
-| short name | long name  | description   | default |
+| Short name | Long name  | Description   | Default |
 |------------|------------|---------------|---------------|
-|   | help |   | |
-|   | parallelMode |   | |
-|   | threads |   | |
-|   | propertiesFile  |   | |
-|   | quiet  |   | |
-|   | reportType  |   | |
-|   | excludeSuites  |   | |
-|   | includeSuites  |   | |
-|   | language  |   | |
-|   | testRootPath | relative path from place, where save.properties is stored or absolute path  | |
-|   | resultOutput |   | |
-|   | disableConfigInheritance |   | |
-|   | ignoreTechnicalComments | should ignore our technical special comments that we use to describe warnings  | |
-|   | reportDir |   | |
-|   | runSingleTest | in case you need to run a single test - just provide a path to the file with 'Test' postfix and save will run it | |
+| h | help | Usage info | - |
+| c | config | Path to the root save config file | save.toml |
+| parallel | parallel-mode | Whether to enable parallel mode | false |
+| t | threads | Number of threads | 1 |
+| prop | properties-file  | Path to the file with configuration properties of save application | save.properties |
+| d | debug | Turn on debug logging | false |
+| q | quiet | Do not log anything  | false |
+| - | report-type | Possible types of output formats | JSON |
+| b | baseline | Path to the file with baseline data | - |
+| e | exclude-suites | Test suites, which won't be checked | - |
+| i | include-suites | Test suites, only which ones will be checked | - |
+| l | language  | Language that you are developing analyzer for | java |
+| - | test-root-path | Path to directory with tests (relative path from place, where save.properties is stored or absolute path)  | - |
+| output | result-output | Data output stream | STDOUT |
+| - | config-inheritance | Whether configuration files could inherit configurations from the previous level of directories | true |
+| ignore | ignore-technical-comments | Should ignore our technical special comments, that we use to describe warnings  | false |
+| - | report-dir | Path to directory where to store output | save-reports |
+| - | run-single-test | In case you need to run a single test - just provide a path to the file with 'Test' postfix and save will run it | - |
 
 SAVE framework will detect tests, run your analyzer on these tests, will calculate the pass-rate and test results.
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ Most of the options below can be passed to a SAVE via `save.properties` file
 | l | language  | Language that you are developing analyzer for | java |
 | - | test-root-path | Path to directory with tests (relative path from place, where save.properties is stored or absolute path)  | - |
 | output | result-output | Data output stream | STDOUT |
-| - | config-inheritance | Whether configuration files could inherit configurations from the previous level of directories | true |
-| ignore | ignore-technical-comments | Should ignore our technical special comments, that we use to describe warnings  | false |
-| - | report-dir | Path to directory where to store output | save-reports |
-| - | run-single-test | In case you need to run a single test - just provide a path to the file with 'Test' postfix and save will run it | - |
+| - | config-inheritance | Whether configuration files should inherit configurations from the previous level of directories | true |
+| ignore | ignore-technical-comments | If true, ignore technical comments, that SAVE uses to describe warnings, when running tests  | false |
+| - | report-dir | Path to directory where to store output (when `resultOutput` is set to `FILE`) | save-reports |
+| - | run-single-test | In case you need to run a single test - just provide a path to the file with 'Test' postfix and SAVE will run it | - |
 
 SAVE framework will detect tests, run your analyzer on these tests, will calculate the pass-rate and test results.
 

--- a/README.md
+++ b/README.md
@@ -88,11 +88,10 @@ Most of the options below can be passed to a SAVE via `save.properties` file
 | i | include-suites | Test suites, only which ones will be checked | - |
 | l | language  | Language that you are developing analyzer for | java |
 | - | test-root-path | Path to directory with tests (relative path from place, where save.properties is stored or absolute path)  | - |
-| output | result-output | Data output stream | STDOUT |
+| out | result-output | Data output stream | STDOUT |
 | - | config-inheritance | Whether configuration files should inherit configurations from the previous level of directories | true |
-| ignore | ignore-technical-comments | If true, ignore technical comments, that SAVE uses to describe warnings, when running tests  | false |
+| - | ignore-save-comments | If true, ignore technical comments, that SAVE uses to describe warnings, when running tests  | false |
 | - | report-dir | Path to directory where to store output (when `resultOutput` is set to `FILE`) | save-reports |
-| - | run-single-test | In case you need to run a single test - just provide a path to the file with 'Test' postfix and SAVE will run it | - |
 
 SAVE framework will detect tests, run your analyzer on these tests, will calculate the pass-rate and test results.
 

--- a/save-cli/src/commonMain/kotlin/org/cqfn/save/cli/Config.kt
+++ b/save-cli/src/commonMain/kotlin/org/cqfn/save/cli/Config.kt
@@ -4,7 +4,9 @@
 
 package org.cqfn.save.cli
 
+import org.cqfn.save.core.config.LanguageType
 import org.cqfn.save.core.config.ReportType
+import org.cqfn.save.core.config.ResultOutputType
 import org.cqfn.save.core.config.SaveConfig
 
 import okio.Path.Companion.toPath
@@ -12,6 +14,8 @@ import okio.Path.Companion.toPath
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
+import kotlinx.cli.multiple
+import kotlinx.cli.required
 
 /**
  * @param args CLI args
@@ -25,6 +29,26 @@ fun createConfigFromArgs(args: Array<String>): SaveConfig {
         shortName = "c",
         description = "Path to the root save config file",
     ).default("save.toml")
+
+    val parallelMode by parser.option(
+        ArgType.Boolean,
+        fullName = "parallel-mode",
+        shortName = "parallel",
+        description = "Whether to enable parallel mode",
+    ).default(false)
+
+    val threads by parser.option(
+        ArgType.Int,
+        shortName = "t",
+        description = "Number of threads",
+    ).default(1)
+
+    val propertiesFile by parser.option(
+        ArgType.String,
+        fullName = "properties-file",
+        shortName = "prop",
+        description = "Path to the file with configuration properties of save application",
+    ).default("save.properties")
 
     val debug by parser.option(
         ArgType.Boolean,
@@ -40,7 +64,8 @@ fun createConfigFromArgs(args: Array<String>): SaveConfig {
 
     val reportType by parser.option(
         ArgType.Choice<ReportType>(),
-        shortName = "r",
+        fullName = "report-type",
+        description = "Possible types of output formats"
     ).default(ReportType.JSON)
 
     val baseline by parser.option(
@@ -49,12 +74,82 @@ fun createConfigFromArgs(args: Array<String>): SaveConfig {
         description = "Path to the file with baseline data",
     )
 
+    val excludeSuites by parser.option(
+        ArgType.String,
+        fullName = "exclude-suites",
+        shortName = "e",
+        description = "Test suites, which won't be checked",
+    ).multiple()
+
+    val includeSuites by parser.option(
+        ArgType.String,
+        fullName = "include-suites",
+        shortName = "i",
+        description = "Test suites, only which ones will be checked",
+    ).multiple()
+
+    val language by parser.option(
+        ArgType.Choice<LanguageType>(),
+        shortName = "l",
+        description = "Language that you are developing analyzer for",
+    ).default(LanguageType.JAVA)
+
+    val testRootPath by parser.option(
+        ArgType.String,
+        fullName = "test-root-path",
+        description = "Path to directory with tests (relative path from place, where save.properties is stored or absolute path)",
+    ).required()
+
+    val resultOutput by parser.option(
+        ArgType.Choice<ResultOutputType>(),
+        fullName = "result-output",
+        shortName = "output",
+        description = "Data output stream",
+    ).default(ResultOutputType.STDOUT)
+
+    val configInheritance by parser.option(
+        ArgType.Boolean,
+        fullName = "config-inheritance",
+        description = "Whether configuration files could inherit configurations from the previous level of directories",
+    ).default(true)
+
+    val ignoreTechnicalComments by parser.option(
+        ArgType.Boolean,
+        fullName = "ignore-technical-comments",
+        shortName = "ignore",
+        description = "Should ignore our technical special comments, that we use to describe warnings",
+    ).default(false)
+
+    val reportDir by parser.option(
+        ArgType.String,
+        fullName = "report-dir",
+        description = "Path to directory, where to store output",
+    ).default("save-reports")
+
+    val runSingleTest by parser.option(
+        ArgType.String,
+        fullName = "run-single-test",
+        description = "Path to the file with 'Test' postfix, which need to be run in single mode",
+    )
+
     parser.parse(args)
     return SaveConfig(
         configPath = config.toPath(),
+        parallelMode = parallelMode,
+        threads = threads,
+        propertiesFile = propertiesFile.toPath(),
         debug = debug,
         quiet = quiet,
         reportType = reportType,
-        baselinePath = baseline?.toPath()
+        baselinePath = baseline?.toPath(),
+        excludeSuites = excludeSuites,
+        includeSuites = includeSuites,
+        language = language,
+        testRootPath = testRootPath.toPath(),
+        resultOutput = resultOutput,
+        configInheritance = configInheritance,
+        ignoreTechnicalComments = ignoreTechnicalComments,
+        reportDir = reportDir.toPath(),
+        runSingleTest = runSingleTest?.toPath()
     )
 }

--- a/save-cli/src/commonMain/kotlin/org/cqfn/save/cli/Config.kt
+++ b/save-cli/src/commonMain/kotlin/org/cqfn/save/cli/Config.kt
@@ -104,7 +104,7 @@ fun createConfigFromArgs(args: Array<String>): SaveConfig {
     val resultOutput by parser.option(
         ArgType.Choice<ResultOutputType>(),
         fullName = "result-output",
-        shortName = "output",
+        shortName = "out",
         description = "Data output stream",
     ).default(ResultOutputType.STDOUT)
 
@@ -114,10 +114,9 @@ fun createConfigFromArgs(args: Array<String>): SaveConfig {
         description = "Whether configuration files should inherit configurations from the previous level of directories",
     ).default(true)
 
-    val ignoreTechnicalComments by parser.option(
+    val ignoreSaveComments by parser.option(
         ArgType.Boolean,
-        fullName = "ignore-technical-comments",
-        shortName = "ignore",
+        fullName = "ignore-save-comments",
         description = "If true, ignore technical comments, that SAVE uses to describe warnings, when running tests",
     ).default(false)
 
@@ -126,12 +125,6 @@ fun createConfigFromArgs(args: Array<String>): SaveConfig {
         fullName = "report-dir",
         description = "Path to directory, where to store output (when `resultOutput` is set to `FILE`)",
     ).default("save-reports")
-
-    val runSingleTest by parser.option(
-        ArgType.String,
-        fullName = "run-single-test",
-        description = "Path to the file with 'Test' postfix, which need to be run in single mode",
-    )
 
     parser.parse(args)
     return SaveConfig(
@@ -149,8 +142,7 @@ fun createConfigFromArgs(args: Array<String>): SaveConfig {
         testRootPath = testRootPath.toPath(),
         resultOutput = resultOutput,
         configInheritance = configInheritance,
-        ignoreTechnicalComments = ignoreTechnicalComments,
+        ignoreSaveComments = ignoreSaveComments,
         reportDir = reportDir.toPath(),
-        runSingleTest = runSingleTest?.toPath()
     )
 }

--- a/save-cli/src/commonMain/kotlin/org/cqfn/save/cli/Config.kt
+++ b/save-cli/src/commonMain/kotlin/org/cqfn/save/cli/Config.kt
@@ -21,6 +21,7 @@ import kotlinx.cli.required
  * @param args CLI args
  * @return an instance of [SaveConfig]
  */
+@Suppress("TOO_LONG_FUNCTION")
 fun createConfigFromArgs(args: Array<String>): SaveConfig {
     val parser = ArgParser("save")
 
@@ -110,20 +111,20 @@ fun createConfigFromArgs(args: Array<String>): SaveConfig {
     val configInheritance by parser.option(
         ArgType.Boolean,
         fullName = "config-inheritance",
-        description = "Whether configuration files could inherit configurations from the previous level of directories",
+        description = "Whether configuration files should inherit configurations from the previous level of directories",
     ).default(true)
 
     val ignoreTechnicalComments by parser.option(
         ArgType.Boolean,
         fullName = "ignore-technical-comments",
         shortName = "ignore",
-        description = "Should ignore our technical special comments, that we use to describe warnings",
+        description = "If true, ignore technical comments, that SAVE uses to describe warnings, when running tests",
     ).default(false)
 
     val reportDir by parser.option(
         ArgType.String,
         fullName = "report-dir",
-        description = "Path to directory, where to store output",
+        description = "Path to directory, where to store output (when `resultOutput` is set to `FILE`)",
     ).default("save-reports")
 
     val runSingleTest by parser.option(

--- a/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/LanguageType.kt
+++ b/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/LanguageType.kt
@@ -3,6 +3,7 @@ package org.cqfn.save.core.config
 /**
  * Available languages
  */
+@Suppress("IDENTIFIER_LENGTH")
 enum class LanguageType {
-    JAVA, CPP, C, KOTLIN
+    C, CPP, JAVA, KOTLIN
 }

--- a/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/LanguageType.kt
+++ b/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/LanguageType.kt
@@ -1,0 +1,8 @@
+package org.cqfn.save.core.config
+
+/**
+ * Available languages
+ */
+enum class LanguageType {
+    JAVA, CPP, C, KOTLIN
+}

--- a/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/ResultOutputType.kt
+++ b/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/ResultOutputType.kt
@@ -4,5 +4,5 @@ package org.cqfn.save.core.config
  * Possible data output streams
  */
 enum class ResultOutputType {
-    STDERR, STDOUT, FILE
+    FILE, STDERR, STDOUT
 }

--- a/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/ResultOutputType.kt
+++ b/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/ResultOutputType.kt
@@ -1,0 +1,8 @@
+package org.cqfn.save.core.config
+
+/**
+ * Possible data output streams
+ */
+enum class ResultOutputType {
+    STDERR, STDOUT, FILE
+}

--- a/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/SaveConfig.kt
+++ b/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/SaveConfig.kt
@@ -4,19 +4,43 @@ import okio.ExperimentalFileSystem
 import okio.Path
 
 /**
- * Configuration properties of save application, retrieved either from peoperties file
+ * Configuration properties of save application, retrieved either from properties file
  * or from CLI args.
  * @property configPath path to the configuration file
- * @property debug
- * @property quiet
+ * @property parallelMode whether to enable parallel mode
+ * @property threads number of threads
+ * @property propertiesFile path to the file with configuration properties of save application
+ * @property debug turn on debug logging
+ * @property quiet do not log anything
  * @property reportType type of generated report with execution results
  * @property baselinePath path to the file with baseline data
+ * @property excludeSuites test suites, which won't be checked
+ * @property includeSuites test suites, only which ones will be checked
+ * @property language language that you are developing analyzer for
+ * @property testRootPath path to directory with tests
+ * @property resultOutput data output stream
+ * @property configInheritance whether configuration files could inherit configurations from the previous level of directories
+ * @property ignoreTechnicalComments should ignore our technical special comments, that we use to describe warnings
+ * @property reportDir path to directory where to store output
+ * @property runSingleTest path to the file with 'Test' postfix, which need to be run in single mode
  */
 @OptIn(ExperimentalFileSystem::class)
 data class SaveConfig(
     val configPath: Path,
+    val parallelMode: Boolean,
+    val threads: Int,
+    val propertiesFile: Path,
     val debug: Boolean,
     val quiet: Boolean,
     val reportType: ReportType,
     val baselinePath: Path?,
+    val excludeSuites: List<String>,
+    val includeSuites: List<String>,
+    val language: LanguageType,
+    val testRootPath: Path,
+    val resultOutput: ResultOutputType,
+    val configInheritance: Boolean,
+    val ignoreTechnicalComments: Boolean,
+    val reportDir: Path,
+    val runSingleTest: Path?
 )

--- a/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/SaveConfig.kt
+++ b/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/SaveConfig.kt
@@ -20,9 +20,8 @@ import okio.Path
  * @property testRootPath path to directory with tests
  * @property resultOutput data output stream
  * @property configInheritance whether configuration files should inherit configurations from the previous level of directories
- * @property ignoreTechnicalComments if true, ignore technical comments, that SAVE uses to describe warnings, when running tests
+ * @property ignoreSaveComments if true, ignore technical comments, that SAVE uses to describe warnings, when running tests
  * @property reportDir path to directory where to store output (when `resultOutput` is set to `FILE`)
- * @property runSingleTest path to the file with 'Test' postfix, which need to be run in single mode
  */
 @OptIn(ExperimentalFileSystem::class)
 data class SaveConfig(
@@ -40,7 +39,6 @@ data class SaveConfig(
     val testRootPath: Path,
     val resultOutput: ResultOutputType,
     val configInheritance: Boolean,
-    val ignoreTechnicalComments: Boolean,
+    val ignoreSaveComments: Boolean,
     val reportDir: Path,
-    val runSingleTest: Path?
 )

--- a/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/SaveConfig.kt
+++ b/save-core/src/commonMain/kotlin/org/cqfn/save/core/config/SaveConfig.kt
@@ -19,9 +19,9 @@ import okio.Path
  * @property language language that you are developing analyzer for
  * @property testRootPath path to directory with tests
  * @property resultOutput data output stream
- * @property configInheritance whether configuration files could inherit configurations from the previous level of directories
- * @property ignoreTechnicalComments should ignore our technical special comments, that we use to describe warnings
- * @property reportDir path to directory where to store output
+ * @property configInheritance whether configuration files should inherit configurations from the previous level of directories
+ * @property ignoreTechnicalComments if true, ignore technical comments, that SAVE uses to describe warnings, when running tests
+ * @property reportDir path to directory where to store output (when `resultOutput` is set to `FILE`)
  * @property runSingleTest path to the file with 'Test' postfix, which need to be run in single mode
  */
 @OptIn(ExperimentalFileSystem::class)


### PR DESCRIPTION
### What's done:
* Add options descriptions and short names to the README and Config class