### PR TITLE
Handle extra whitespaces and newlines in Windows `echo`

### DIFF
--- a/save-core/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessBuilder.kt
+++ b/save-core/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessBuilder.kt
@@ -15,7 +15,6 @@ import okio.Path
 import okio.Path.Companion.toPath
 
 import kotlinx.datetime.Clock
-import kotlin.math.min
 
 /**
  * A class that is capable of executing processes, specific to different OS and returning their output.
@@ -88,11 +87,12 @@ class ProcessBuilder {
             logWarn("Found user provided redirections in `$command`. " +
                     "SAVE uses own redirections for internal purpose and will redirect all streams to $tmpDir")
         }
-        if (isCurrentOsWindows()) {
-            // TODO use return value
+        val commandWithEcho = if (isCurrentOsWindows()) {
             processCommandWithEcho(command)
+        } else {
+            command
         }
-        val cmd = processBuilderInternal.prepareCmd(command)
+        val cmd = processBuilderInternal.prepareCmd(commandWithEcho)
         logDebug("Executing: $cmd")
         val status = try {
             processBuilderInternal.exec(cmd)
@@ -115,66 +115,6 @@ class ProcessBuilder {
         return ExecutionResult(status, stdout, stderr)
     }
 
-    companion object {
-        fun processCommandWithEcho(command: String): String {
-            if (!command.contains("echo")) {
-                return command
-            }
-            // Command already contains correct signature.
-            // We also believe not to met complex cases: `echo a; echo | set /p="a && echo b"`,
-            // when there is additionally exists `echo` without `set /p`,
-            // we suppose, that when user use `set /p` he knew what he did
-            val cmdWithoutWhitespaces = command.replace(" ", "")
-            if (cmdWithoutWhitespaces.contains("echo|set")) {
-                return command
-            }
-            if (cmdWithoutWhitespaces.contains("echo\"")) {
-                logWarn("Please use echo | set /p\"your command\" to avoid extra whitespaces on Windows")
-                return command
-            }
-            // If command is complex, we need to modify only `echo` subcommands
-            val separator = if (command.contains("&&")) "&&" else if (command.contains(";")) ";" else ""
-            val listOfCommands = if (separator != "") command.split(separator) as MutableList<String> else mutableListOf(command)
-            println("Before ${listOfCommands}")
-            println(command)
-            listOfCommands.forEachIndexed { index, cmd ->
-                println("CMD: ${cmd}")
-                if (cmd.contains("echo")) {
-                    var newEchoCommand = cmd.trim(' ').replace("echo ", " echo | set /p=\"")
-                    // Despite the fact, that we don't expect user redirections, for out internal tests we use them,
-                    // so we need to process such cases
-                    // There three different cases, when we need to insert closing `"`.
-                    // 1) Before stdout redirection
-                    // 2) Before stderr redirection
-                    // 3) At the end of string, if there is no redirections
-                    val indexOfStdoutRedirection = if (newEchoCommand.indexOf(">") != -1) newEchoCommand.indexOf(">") else newEchoCommand.length
-                    val indexOfStderrRedirection = if (newEchoCommand.indexOf("2>") != -1) newEchoCommand.indexOf("2>") else newEchoCommand.length
-                    val insertIndex = minOf(indexOfStdoutRedirection, indexOfStderrRedirection)//, newEchoCommand.length - 1)
-                    //println("${newEchoCommand}|")
-                    //println(" indexOfStdoutRedirection ${indexOfStdoutRedirection}")
-                    //println(" indexOfStderrRedirection ${indexOfStderrRedirection}")
-                    //println(" insertIndex ${insertIndex}")
-                    println(" Substring before ${newEchoCommand.substring(0, insertIndex)}|")
-                    println(" Substring after ${newEchoCommand.substring(insertIndex, newEchoCommand.length)}|")
-                    newEchoCommand = newEchoCommand.substring(0, insertIndex).trimEnd(' ') + "\" " +  newEchoCommand.substring(insertIndex, newEchoCommand.length) + " "
-
-                    listOfCommands[index] = newEchoCommand
-                }
-            }
-            val modifiedCommand = listOfCommands.joinToString(separator).trim(' ')
-            println("After ${listOfCommands}")
-            println(modifiedCommand)
-            return modifiedCommand
-        }
-
-        fun extractEchoCommands(command: String, separator: String): MutableList<String> {
-            val echoCommands: MutableList<String> = mutableListOf()
-            val listOfCommands = command.split(separator).filter { it.contains("echo") }
-            listOfCommands.forEach { echoCommands.add(it.trim(' ')) }
-            return echoCommands
-        }
-    }
-
     /**
      * Log error message and return with status = -1
      *
@@ -184,6 +124,61 @@ class ProcessBuilder {
     private fun returnWithError(errMsg: String): ExecutionResult {
         logError(errMsg)
         return ExecutionResult(-1, emptyList(), listOf(errMsg))
+    }
+
+    companion object {
+        /**
+         * Check whether there are exists `echo` commands, and process them, since in Windows
+         * `echo` adds extra whitespaces and newlines. This method will remove them
+         *
+         * @param command command to process
+         * @return unmodified command, if there is no `echo` subcommands, otherwise add parameter `set /p=` to `echo`
+         */
+        @Suppress("ReturnCount")
+        fun processCommandWithEcho(command: String): String {
+            if (!command.contains("echo")) {
+                return command
+            }
+            // Command already contains correct signature.
+            // We also believe not to met complex cases: `echo a; echo | set /p="a && echo b"`
+            val cmdWithoutWhitespaces = command.replace(" ", "")
+            if (cmdWithoutWhitespaces.contains("echo|set")) {
+                return command
+            }
+            if (cmdWithoutWhitespaces.contains("echo\"")) {
+                logWarn("You can use echo | set /p\"your command\" to avoid extra whitespaces on Windows")
+                return command
+            }
+            // If command is complex (have `&&` or `;`), we need to modify only `echo` subcommands
+            val separator = if (command.contains("&&")) {
+                "&&"
+            } else if (command.contains(";")) {
+                ";"
+            } else {
+                ""
+            }
+            val listOfCommands = if (separator != "") command.split(separator) as MutableList<String> else mutableListOf(command)
+            listOfCommands.forEachIndexed { index, cmd ->
+                if (cmd.contains("echo")) {
+                    var newEchoCommand = cmd.trim(' ').replace("echo ", " echo | set /p=\"")
+                    // Now we need to add closing `"` in proper place
+                    // Despite the fact, that we don't expect user redirections, for out internal tests we use them,
+                    // so we need to process such cases
+                    // There are three different cases, where we need to insert closing `"`.
+                    // 1) Before stdout redirection
+                    // 2) Before stderr redirection
+                    // 3) At the end of string, if there is no redirections
+                    val indexOfStdoutRedirection = if (newEchoCommand.indexOf(">") != -1) newEchoCommand.indexOf(">") else newEchoCommand.length
+                    val indexOfStderrRedirection = if (newEchoCommand.indexOf("2>") != -1) newEchoCommand.indexOf("2>") else newEchoCommand.length
+                    val insertIndex = minOf(indexOfStdoutRedirection, indexOfStderrRedirection)
+                    newEchoCommand = newEchoCommand.substring(0, insertIndex).trimEnd(' ') + "\" " + newEchoCommand.substring(insertIndex, newEchoCommand.length) + " "
+                    listOfCommands[index] = newEchoCommand
+                }
+            }
+            val modifiedCommand = listOfCommands.joinToString(separator).trim(' ')
+            logDebug("Modify command:`$command` to `$modifiedCommand` because of `echo` on Windows add extra newlines")
+            return modifiedCommand
+        }
     }
 }
 

--- a/save-core/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
+++ b/save-core/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
@@ -5,6 +5,7 @@
 package org.cqfn.save.core
 
 import org.cqfn.save.core.utils.ProcessBuilder
+import org.cqfn.save.core.utils.ProcessBuilder.Companion.processCommandWithEcho
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -30,5 +31,40 @@ class ProcessBuilderTest {
         // posix `system()` and JVM process builder returns lines with different whitespaces, so we cut them
         assertEquals(expectedStdout, actualResult.stdout[0].trimEnd())
         assertEquals(expectedStderr, actualResult.stderr)
+    }
+
+    @Test
+    fun `simple check`() {
+        val inputCommand = "echo something"
+        val expectedCommand = "echo | set /p=\"something\""
+        assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
+    }
+
+    @Test
+    fun `simple check with redirection`() {
+        val inputCommand = "echo something > /dev/null"
+        val expectedCommand = "echo | set /p=\"something\" > /dev/null"
+        assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
+    }
+
+    @Test
+    fun `simple check with redirection without first whitespace`() {
+        val inputCommand = "echo something> /dev/null"
+        val expectedCommand = "echo | set /p=\"something\" > /dev/null"
+        assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
+    }
+
+    @Test
+    fun `simple check with redirection without whitespaces at all`() {
+        val inputCommand = "echo something>/dev/null"
+        val expectedCommand = "echo | set /p=\"something\" >/dev/null"
+        assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
+    }
+
+    @Test
+    fun `change multiple echo commands with redirections`() {
+        val inputCommand = "echo a > /dev/null && echo b 2>/dev/null && ls"
+        val expectedCommand = "echo | set /p=\"a\" > /dev/null && echo | set /p=\"b\" 2>/dev/null && ls"
+        assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 }

--- a/save-core/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
+++ b/save-core/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
@@ -6,6 +6,7 @@ package org.cqfn.save.core
 
 import org.cqfn.save.core.utils.ProcessBuilder
 import org.cqfn.save.core.utils.ProcessBuilder.Companion.processCommandWithEcho
+import org.cqfn.save.core.utils.isCurrentOsWindows
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -24,13 +25,19 @@ class ProcessBuilderTest {
     @Test
     fun `check stdout`() {
         val actualResult = processBuilder.exec("echo something", null)
-        val expectedCode = 0
-        val expectedStdout = "something"
+        val expectedCode = if (isCurrentOsWindows()) 1 else 0
+        val expectedStdout = listOf("something")
         val expectedStderr: List<String> = emptyList()
         assertEquals(expectedCode, actualResult.code)
         // posix `system()` and JVM process builder returns lines with different whitespaces, so we cut them
-        assertEquals(expectedStdout, actualResult.stdout[0].trimEnd())
+        assertEquals(expectedStdout, actualResult.stdout)
         assertEquals(expectedStderr, actualResult.stderr)
+    }
+
+    @Test
+    fun `command without echo`() {
+        val inputCommand = "cd /some/dir; cat /some/file ; ls"
+        assertEquals(inputCommand, processCommandWithEcho(inputCommand))
     }
 
     @Test
@@ -62,9 +69,37 @@ class ProcessBuilderTest {
     }
 
     @Test
+    fun `one long echo`() {
+        val inputCommand = "echo stub STUB stub foo bar "
+        val expectedCommand = "echo | set /p=\"stub STUB stub foo bar\""
+        assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
+    }
+
+    @Test
     fun `change multiple echo commands with redirections`() {
         val inputCommand = "echo a > /dev/null && echo b 2>/dev/null && ls"
         val expectedCommand = "echo | set /p=\"a\" > /dev/null && echo | set /p=\"b\" 2>/dev/null && ls"
+        assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
+    }
+
+    @Test
+    fun `change multiple echo commands with redirections 2`() {
+        val inputCommand = "echo a > /dev/null ; echo b 2>/dev/null ; ls"
+        val expectedCommand = "echo | set /p=\"a\" > /dev/null ; echo | set /p=\"b\" 2>/dev/null ; ls"
+        assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
+    }
+
+    @Test
+    fun `change multiple echo commands with redirections 3`() {
+        val inputCommand = "echo a > /dev/null; echo b 2>/dev/null; ls"
+        val expectedCommand = "echo | set /p=\"a\" > /dev/null ; echo | set /p=\"b\" 2>/dev/null ; ls"
+        assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
+    }
+
+    @Test
+    fun `extra whitespaces shouldn't influence to echo`() {
+        val inputCommand = "echo foo bar ; echo b; ls"
+        val expectedCommand = "echo | set /p=\"foo bar\"  ; echo | set /p=\"b\"  ; ls"
         assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 }

--- a/save-core/src/nativeTest/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternalTest.kt
+++ b/save-core/src/nativeTest/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternalTest.kt
@@ -10,12 +10,12 @@ class ProcessBuilderInternalTest {
     @Test
     fun `check stdout with redirection`() {
         val actualResult = processBuilder.exec("echo something >/dev/null", null)
-        val expectedCode = 0
-        val expectedStdout = "something"
+        val expectedCode = if (isCurrentOsWindows()) 1 else 0
+        val expectedStdout = listOf("something")
         val expectedStderr: List<String> = emptyList()
         assertEquals(expectedCode, actualResult.code)
         // posix popen and JVM process builder returns lines with different whitespaces, so we cut them
-        assertEquals(expectedStdout, actualResult.stdout[0].trimEnd())
+        assertEquals(expectedStdout, actualResult.stdout)
         assertEquals(expectedStderr, actualResult.stderr)
     }
 

--- a/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
+++ b/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
@@ -89,8 +89,7 @@ class FixPluginTest {
         }
         val expectedFile = fs.createFile(tmpDir / "Test3Expected.java")
         fs.write(expectedFile) {
-            val textPostfix = if (isCurrentOsWindows()) " \n" else ""
-            write("Expected file$textPostfix".encodeToByteArray())
+            write("Expected file".encodeToByteArray())
         }
 
         val diskWithTmpDir = if (isCurrentOsWindows()) "${tmpDir.toString().substringBefore("\\").toLowerCase()} && " else ""
@@ -121,8 +120,7 @@ class FixPluginTest {
         }
         val expectedFile = fs.createFile(tmpDir / "Test3Expected.java")
         fs.write(expectedFile) {
-            val textPostfix = if (isCurrentOsWindows()) " \n" else ""
-            write("Expected file$textPostfix".encodeToByteArray())
+            write("Expected file".encodeToByteArray())
         }
         val diskWithTmpDir = if (isCurrentOsWindows()) "${tmpDir.toString().substringBefore("\\").toLowerCase()} && " else ""
         val executionCmd = "${diskWithTmpDir}cd $tmpDir && echo Expected file > Test3Test_copy.java"


### PR DESCRIPTION
### What's done:
* Provide additional function which will wrap `echo` command on Windows in the following manner `echo | set /p="command"`
* Add tests for this wrap algorithm
* Fix old tests, which uses `echo` commands