### PR TITLE
Distinguish resources among different SAVE configs

### DIFF
--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/files/FileUtils.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/files/FileUtils.kt
@@ -87,7 +87,7 @@ fun FileSystem.readLines(path: Path): List<String> = this.read(path) {
  * |   |-- directory23
  * |   |   `-- file33
  * ```
- * If predicate returns `true` when `Path` is a directory which contains only other directories, then `directory11` will be filtered, as well as
+ * If predicate returns `true` when `Path` is a directory which contains only other directories or is empty, then `directory11` will be filtered, as well as
  * `directory21`, which is empty, but is a descendant of already filtered out one, and `directory 23`, which is not empty.
  * So, the result would be `sequence(directory12, directory13)`
  *

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/files/FileUtils.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/files/FileUtils.kt
@@ -93,12 +93,12 @@ fun FileSystem.readLines(path: Path): List<String> = this.read(path) {
  * @return a sequence of matching directories
  */
 fun Path.findDescendantDirectoriesBy(directoryPredicate: (Path) -> Boolean): Sequence<Path> =
-    sequence {
-        yield(this@findDescendantDirectoriesBy)
-        FileSystem.SYSTEM.list(this@findDescendantDirectoriesBy)
-            .asSequence()
-            .filter { FileSystem.SYSTEM.metadata(it).isDirectory }
-            .filter(directoryPredicate)
-            .flatMap { it.findDescendantDirectoriesBy(directoryPredicate) }
-            .let { yieldAll(it) }
-    }
+        sequence {
+            yield(this@findDescendantDirectoriesBy)
+            FileSystem.SYSTEM.list(this@findDescendantDirectoriesBy)
+                .asSequence()
+                .filter { FileSystem.SYSTEM.metadata(it).isDirectory }
+                .filter(directoryPredicate)
+                .flatMap { it.findDescendantDirectoriesBy(directoryPredicate) }
+                .let { yieldAll(it) }
+        }

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
@@ -1,12 +1,12 @@
 package org.cqfn.save.core.plugin
 
-import okio.FileSystem
 import org.cqfn.save.core.config.TestConfig
-import org.cqfn.save.core.result.TestResult
-
-import okio.Path
 import org.cqfn.save.core.config.isSaveTomlConfig
 import org.cqfn.save.core.files.findDescendantDirectoriesBy
+import org.cqfn.save.core.result.TestResult
+
+import okio.FileSystem
+import okio.Path
 
 /**
  * Plugin that can be injected into SAVE during execution. Plugins accept contents of configuration file and then perform some work.
@@ -34,6 +34,7 @@ interface Plugin {
      * then this plugin shouldn't touch these resources; it should be done by plugins from that config.
      *
      * @param fs a [FileSystem] which is used to traverse the directory hierarchy
+     * @return a sequence of directories possibly containing this plugin's test resources
      */
     fun Path.resourceDirectories(fs: FileSystem = FileSystem.SYSTEM): Sequence<Path> = findDescendantDirectoriesBy { file ->
         // this matches directories which contain their own SAVE config

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
@@ -36,7 +36,7 @@ interface Plugin {
      * @param fs a [FileSystem] which is used to traverse the directory hierarchy
      * @return a sequence of directories possibly containing this plugin's test resources
      */
-    fun Path.resourceDirectories(fs: FileSystem = FileSystem.SYSTEM): Sequence<Path> = findDescendantDirectoriesBy { file ->
+    fun Path.resourceDirectories(fs: FileSystem = FileSystem.SYSTEM): Sequence<Path> = findDescendantDirectoriesBy(true) { file ->
         // this matches directories which contain their own SAVE config
         fs.metadata(file).isRegularFile || fs.list(file).none { it.isSaveTomlConfig() }
     }

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/PluginConfig.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/PluginConfig.kt
@@ -11,5 +11,9 @@ interface PluginConfig
 
 /**
  * General configuration for test suite.
+ * @property suiteName name of the test suite
  */
-class GeneralConfig : PluginConfig
+@Suppress("INLINE_CLASS_CAN_BE_USED")
+class GeneralConfig(
+    val suiteName: String,
+) : PluginConfig

--- a/save-common/src/commonTest/kotlin/org/cqfn/save/core/files/FileUtilsTest.kt
+++ b/save-common/src/commonTest/kotlin/org/cqfn/save/core/files/FileUtilsTest.kt
@@ -1,0 +1,47 @@
+package org.cqfn.save.core.files
+
+import okio.FileSystem
+import okio.Path
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FileUtilsTest {
+    private val fs = FileSystem.SYSTEM
+    private lateinit var tmpDir: Path
+
+    @BeforeTest
+    fun setUp() {
+        tmpDir = (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "FileUtilsTest").also(fs::createDirectory)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (::tmpDir.isInitialized) {
+            fs.deleteRecursively(tmpDir)
+        }
+    }
+
+    @Test
+    fun `example for findDescendantDirectoriesBy`() {
+        val directory1 = (tmpDir / "directory1").also(fs::createDirectory)
+        fs.createFile(directory1 / "file1")
+        val directory11 = (directory1 / "directory11").also(fs::createDirectory)
+        fs.createFile(directory11 / "file2")
+        fs.createDirectory(directory11 / "directory21")
+        val directory12 = (directory1 / "directory12").also(fs::createDirectory)
+        val directory13 = (directory1 / "directory13").also(fs::createDirectory)
+        val directory23 = (directory13 / "directory23").also(fs::createDirectory)
+        fs.createFile(directory23 / "file33")
+
+        val result = directory1.findDescendantDirectoriesBy { dir ->
+            fs.list(dir).none { fs.metadata(it).isRegularFile }
+        }
+            .toList()
+
+        assertEquals(2, result.size)
+        assertEquals(directory12, result.first())
+        assertEquals(directory13, result[1])
+    }
+}

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -1,7 +1,6 @@
 package org.cqfn.save.plugins.fix
 
 import org.cqfn.save.core.config.TestConfig
-import org.cqfn.save.core.files.findAllFilesMatching
 import org.cqfn.save.core.files.readLines
 import org.cqfn.save.core.logging.logInfo
 import org.cqfn.save.core.plugin.Plugin
@@ -65,8 +64,8 @@ class FixPlugin : Plugin {
     }
 
     override fun discoverTestFiles(root: Path): Sequence<List<Path>> = root
-        .findAllFilesMatching { true }
-        .asSequence()
+        .resourceDirectories()
+        .map { FileSystem.SYSTEM.list(it) }
         .flatMap { files ->
             files.groupBy {
                 val matchResult = defaultResourceNamePattern.matchEntire(it.name)

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -34,8 +34,10 @@ class WarnPlugin : Plugin {
     }
 
     override fun discoverTestFiles(root: Path) = root
-        .findAllFilesMatching {
-            defaultResourceNamePattern.matches(it.name)
+        .resourceDirectories()
+        .map { directory ->
+            FileSystem.SYSTEM.list(directory)
+                .filter { defaultResourceNamePattern.matches(it.name) }
         }
         .asSequence()
         .map { listOf(it) }

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -1,7 +1,6 @@
 package org.cqfn.save.plugin.warn
 
 import org.cqfn.save.core.config.TestConfig
-import org.cqfn.save.core.files.findAllFilesMatching
 import org.cqfn.save.core.files.readLines
 import org.cqfn.save.core.plugin.Plugin
 import org.cqfn.save.core.result.DebugInfo


### PR DESCRIPTION
### What's done:
* Introduced default method `resourceDirectories` in `Plugin` to get resource directories managed by this config
* Added `suiteName` property to `GeneralConfig`

### TODO:
* Call this method in plugin interface