### PR TITLE
Version updates

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,15 +33,13 @@ jobs:
       - name: Start Gradle remote cache server
         uses: burrunan/gradle-cache-action@v1
         with:
-          properties: |
-            org.gradle.caching=true
           gradle-version: wrapper
           # additional files to calculate key for dependency cache
           gradle-dependencies-cache-key: |
             buildSrc/**/Versions.kt
       # Until https://github.com/burrunan/gradle-cache-action/issues/42 is addressed, gradle should be run as a separate step
       - name: Run gradle command
-        run: ./gradlew build
+        run: ./gradlew build --build-cache
       - name: Upload gradle reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run gradle command
         run: |
           chmod +x gradlew
-          ./gradlew build -x detekt 2>&1 | sed 's/error:/e:/'
+          ./gradlew build -x detekt
       - name: Upload gradle reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run gradle command
         run: |
           chmod +x gradlew
-          ./gradlew build -x detekt | sed 's/error:/e:/'
+          ./gradlew build -x detekt 2>&1 | sed 's/error:/e:/'
       - name: Upload gradle reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build_and_test_with_code_coverage:
-    if: ${{ false }}
     name: Build and test
     runs-on: ${{ matrix.os }}
     strategy:
@@ -31,19 +30,18 @@ jobs:
           key: ${{ runner.os }}-gradle-konan
           restore-keys: |
             ${{ runner.os }}-gradle-konan
-      - name: Gradle build with remote cache
+      - name: Start Gradle remote cache server
         uses: burrunan/gradle-cache-action@v1
         with:
-          arguments: |
-            build
-          # FixMe: https://github.com/cqfn/save/issues/67
-          #  -x detekt
           properties: |
             org.gradle.caching=true
           gradle-version: wrapper
           # additional files to calculate key for dependency cache
           gradle-dependencies-cache-key: |
             buildSrc/**/Versions.kt
+      # Until https://github.com/burrunan/gradle-cache-action/issues/42 is addressed, gradle should be run as a separate step
+      - name: Run gradle command
+        run: ./gradlew build
       - name: Upload gradle reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build_and_test_with_code_coverage:
+    if: ${{ false }}
     name: Build and test
     runs-on: ${{ matrix.os }}
     strategy:
@@ -33,16 +34,15 @@ jobs:
       - name: Gradle build with remote cache
         uses: burrunan/gradle-cache-action@v1
         with:
+          arguments: |
+            build
+            -x detekt
           properties: |
             org.gradle.caching=true
           gradle-version: wrapper
           # additional files to calculate key for dependency cache
           gradle-dependencies-cache-key: |
             buildSrc/**/Versions.kt
-      - name: Run gradle command
-        run: |
-          chmod +x gradlew
-          ./gradlew build -x detekt
       - name: Upload gradle reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,8 +30,7 @@ jobs:
           key: ${{ runner.os }}-gradle-konan
           restore-keys: |
             ${{ runner.os }}-gradle-konan
-      - name: Start Gradle remote cache server
-        uses: burrunan/gradle-cache-action@v1
+      - uses: burrunan/gradle-cache-action@v1
         with:
           gradle-version: wrapper
           # additional files to calculate key for dependency cache

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,15 +33,16 @@ jobs:
       - name: Gradle build with remote cache
         uses: burrunan/gradle-cache-action@v1
         with:
-          arguments: |
-            build
-            -x detekt
           properties: |
             org.gradle.caching=true
           gradle-version: wrapper
           # additional files to calculate key for dependency cache
           gradle-dependencies-cache-key: |
             buildSrc/**/Versions.kt
+      - name: Run gradle command
+        run: |
+          chmod +x gradlew
+          ./gradlew build -x detekt | sed 's/error:/e:/'
       - name: Upload gradle reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -17,13 +17,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      - name: Gradle build with remote cache
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          arguments: detektAll
-          properties: |
-            org.gradle.caching=true
-          gradle-version: wrapper
-          # additional files to calculate key for dependency cache
-          gradle-dependencies-cache-key: |
-            buildSrc/**/Versions.kt
+      - name: Run gradle command
+        run: |
+          chmod +x gradlew
+          ./gradlew detektAll

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -20,13 +20,9 @@ jobs:
       - name: Start Gradle remote cache server
         uses: burrunan/gradle-cache-action@v1
         with:
-          properties: |
-            org.gradle.caching=true
           gradle-version: wrapper
           # additional files to calculate key for dependency cache
           gradle-dependencies-cache-key: |
             buildSrc/**/Versions.kt
       - name: Run gradle command
-        run: |
-          chmod +x gradlew
-          ./gradlew detektAll
+        run: ./gradlew detektAll --build-cache

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -17,8 +17,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      - name: Start Gradle remote cache server
-        uses: burrunan/gradle-cache-action@v1
+      - uses: burrunan/gradle-cache-action@v1
         with:
           gradle-version: wrapper
           # additional files to calculate key for dependency cache

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -17,6 +17,15 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
+      - name: Start Gradle remote cache server
+        uses: burrunan/gradle-cache-action@v1
+        with:
+          properties: |
+            org.gradle.caching=true
+          gradle-version: wrapper
+          # additional files to calculate key for dependency cache
+          gradle-dependencies-cache-key: |
+            buildSrc/**/Versions.kt
       - name: Run gradle command
         run: |
           chmod +x gradlew

--- a/.github/workflows/diktat.yml
+++ b/.github/workflows/diktat.yml
@@ -17,13 +17,15 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      - name: Gradle build with remote cache
+      - name: Start Gradle remote cache server
         uses: burrunan/gradle-cache-action@v1
         with:
-          arguments: diktatCheckAll
           properties: |
             org.gradle.caching=true
           gradle-version: wrapper
           # additional files to calculate key for dependency cache
           gradle-dependencies-cache-key: |
             buildSrc/**/Versions.kt
+      # Until https://github.com/burrunan/gradle-cache-action/issues/42 is addressed, gradle should be run as a separate step
+      - name: Run gradle command
+        run: ./gradlew diktatCheckAll

--- a/.github/workflows/diktat.yml
+++ b/.github/workflows/diktat.yml
@@ -17,8 +17,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-      - name: Start Gradle remote cache server
-        uses: burrunan/gradle-cache-action@v1
+      - uses: burrunan/gradle-cache-action@v1
         with:
           gradle-version: wrapper
           # additional files to calculate key for dependency cache

--- a/.github/workflows/diktat.yml
+++ b/.github/workflows/diktat.yml
@@ -20,12 +20,10 @@ jobs:
       - name: Start Gradle remote cache server
         uses: burrunan/gradle-cache-action@v1
         with:
-          properties: |
-            org.gradle.caching=true
           gradle-version: wrapper
           # additional files to calculate key for dependency cache
           gradle-dependencies-cache-key: |
             buildSrc/**/Versions.kt
       # Until https://github.com/burrunan/gradle-cache-action/issues/42 is addressed, gradle should be run as a separate step
       - name: Run gradle command
-        run: ./gradlew diktatCheckAll
+        run: ./gradlew diktatCheckAll --build-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           gradle-version: wrapper
       # Until https://github.com/burrunan/gradle-cache-action/issues/42 is addressed, gradle should be run as a separate step
       - name: Run gradle command
-        run: ./gradlew linkReleaseExecutableMultiplatform publishToSonatype closeSonatypeStagingRepository
+        run: ./gradlew --build-cache linkReleaseExecutableMultiplatform publishToSonatype closeSonatypeStagingRepository
       - name: Upload artifact
         id: upload_artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Status git beforeafter
         run: git status
       - uses: burrunan/gradle-cache-action@v1
-        name: Start Gradle remote cache server
         with:
           gradle-version: wrapper
       # Until https://github.com/burrunan/gradle-cache-action/issues/42 is addressed, gradle should be run as a separate step

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ] #, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.3
@@ -27,10 +27,12 @@ jobs:
       - name: Status git beforeafter
         run: git status
       - uses: burrunan/gradle-cache-action@v1
-        name: Gradle release with caches caching
+        name: Start Gradle remote cache server
         with:
-          arguments: linkReleaseExecutableMultiplatform publishToSonatype closeSonatypeStagingRepository
           gradle-version: wrapper
+      # Until https://github.com/burrunan/gradle-cache-action/issues/42 is addressed, gradle should be run as a separate step
+      - name: Run gradle command
+        run: ./gradlew linkReleaseExecutableMultiplatform publishToSonatype closeSonatypeStagingRepository
       - name: Upload artifact
         id: upload_artifact
         uses: actions/upload-artifact@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,11 +21,9 @@ allprojects {
         maven(url = "https://kotlin.bintray.com/kotlinx/")
     }
     configureDiktat()
-    // FixMe: https://github.com/cqfn/save/issues/67
     configureDetekt()
 }
 createDiktatTask()
-// FixMe: https://github.com/cqfn/save/issues/67
 createDetektTask()
 installGitHooks()
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,11 +22,11 @@ allprojects {
     }
     configureDiktat()
     // FixMe: https://github.com/cqfn/save/issues/67
-    //configureDetekt()
+    configureDetekt()
 }
 createDiktatTask()
 // FixMe: https://github.com/cqfn/save/issues/67
-//createDetektTask()
+createDetektTask()
 installGitHooks()
 
 configurePublishing()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     implementation("org.cqfn.diktat:diktat-gradle-plugin:0.5.3")
-    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.0")
+    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.16.0")
     runtimeOnly(kotlin("gradle-plugin", "1.5.0"))
     implementation("io.github.gradle-nexus:publish-plugin:1.1.0")
     implementation("org.ajoberstar.reckon:reckon-gradle:0.13.0")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,9 +7,9 @@ repositories {
 }
 
 dependencies {
-    implementation("org.cqfn.diktat:diktat-gradle-plugin:0.5.1")
-    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.16.0")
-    runtimeOnly(kotlin("gradle-plugin", "1.4.32"))
+    implementation("org.cqfn.diktat:diktat-gradle-plugin:0.5.3")
+    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.0")
+    runtimeOnly(kotlin("gradle-plugin", "1.5.0"))
     implementation("io.github.gradle-nexus:publish-plugin:1.1.0")
     implementation("org.ajoberstar.reckon:reckon-gradle:0.13.0")
     implementation("com.squareup:kotlinpoet:1.8.0")

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -4,7 +4,7 @@ object Versions {
     const val kotlin = "1.5.0"
     const val junit = "5.7.2"
     const val okio = "3.0.0-alpha.1"
-    const val ktoml = "0.2.1"
+    const val ktoml = "0.2.4"
 
     object Kotlinx {
         const val serialization = "1.1.0"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -8,7 +8,7 @@ object Versions {
 
     object Kotlinx {
         const val serialization = "1.1.0"
-        const val datetime = "0.1.1"
+        const val datetime = "0.2.0"
         const val cli = "0.3.2"
     }
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,8 +1,8 @@
 @file:Suppress("PACKAGE_NAME_MISSING", "CONSTANT_UPPERCASE")
 
 object Versions {
-    const val kotlin = "1.4.32"
-    const val junit = "5.7.1"
+    const val kotlin = "1.5.0"
+    const val junit = "5.7.2"
     const val okio = "3.0.0-alpha.1"
     const val ktoml = "0.2.1"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,7 +6,7 @@ object Versions {
     const val okio = "3.0.0-alpha.1"
     const val ktoml = "0.2.4"
 
-    // kek wait
+    // kek waitttt
     object Kotlinx {
         const val serialization = "1.1.0"
         const val datetime = "0.1.1"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,6 +6,7 @@ object Versions {
     const val okio = "3.0.0-alpha.1"
     const val ktoml = "0.2.4"
 
+    // kek wait
     object Kotlinx {
         const val serialization = "1.1.0"
         const val datetime = "0.1.1"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,7 +6,6 @@ object Versions {
     const val okio = "3.0.0-alpha.1"
     const val ktoml = "0.2.4"
 
-    // kek waitttt
     object Kotlinx {
         const val serialization = "1.1.0"
         const val datetime = "0.1.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,11 @@
 group=org.cqfn.save
-kotlin.code.style=official
-kotlin.mpp.stability.nowarn=true
+
 # gradle performance
 org.gradle.parallel=true
 org.gradle.vfs.watch=true
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m
+
+# Kotlin
+kotlin.code.style=official
+kotlin.mpp.stability.nowarn=true
+kotlin.native.cacheKind.linuxX64=static

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/PlatformUtils.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/PlatformUtils.kt
@@ -2,7 +2,7 @@
  * This file contains platform-dependent utils
  */
 
-@file:Suppress("FILE_NAME_MATCH_CLASS")
+@file:Suppress("FILE_NAME_MATCH_CLASS", "MatchingDeclarationName")
 
 package org.cqfn.save.core.utils
 

--- a/save-plugins/fix-plugin/build.gradle.kts
+++ b/save-plugins/fix-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":save-common"))
-                implementation("io.github.petertrr:kotlin-multiplatform-diff:0.1.0")
+                implementation("io.github.petertrr:kotlin-multiplatform-diff:0.2.0")
             }
         }
         val commonTest by getting {

--- a/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
+++ b/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
@@ -74,7 +74,7 @@ class FixPluginTest {
             write("Expected file".encodeToByteArray())
         }
 
-        val diskWithTmpDir = if (isCurrentOsWindows()) "${tmpDir.toString().substringBefore("\\").toLowerCase()} && " else ""
+        val diskWithTmpDir = if (isCurrentOsWindows()) "${tmpDir.toString().substringBefore("\\").lowercase()} && " else ""
         val executionCmd = "${diskWithTmpDir}cd $tmpDir && echo Expected file > Test3Test.java"
 
         val results = FixPlugin().execute(
@@ -104,7 +104,7 @@ class FixPluginTest {
         fs.write(expectedFile) {
             write("Expected file".encodeToByteArray())
         }
-        val diskWithTmpDir = if (isCurrentOsWindows()) "${tmpDir.toString().substringBefore("\\").toLowerCase()} && " else ""
+        val diskWithTmpDir = if (isCurrentOsWindows()) "${tmpDir.toString().substringBefore("\\").lowercase()} && " else ""
         val executionCmd = "${diskWithTmpDir}cd $tmpDir && echo Expected file > Test3Test_copy.java"
 
         val results = FixPlugin().execute(


### PR DESCRIPTION
### What's done:
* Update Koltin from 1.4.32 to 1.5
* Update diktat from 0.5.1 to 0.5.3
* Update junit from 5.7.1 to 5.7.2
* Update kotlin-multiplatform-diff from 0.1.0 to 0.2.0
* Update kotlinx.datetime from 0.1.1 to 0.2.0
* Separate gradle cache server from gradle execution
* Re-enable detekt task
* Enable MacOS runner for release workflow
* Enable Kotlin compilation cache for LinuxX64
* Fixed deprecated methods

Probably, closes #67. With this workaround gradle tasks results are not cached, but other caches keep working.