### PR TITLE
Handle execution output from ProcessBuilder in Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Save can be used not only with static analyzers, but can be used as a test frame
 
 ## How to configure 
 SAVE has a command line interface that runs the framework and your executable. What you need is simply to configure the output of your static analyzer so SAVE will be able to
-check if the proper error was raised on the proper line of test code.
+check if the proper error was raised on the proper line of test code.\
+**Note:** Your application should return 0 in case of successful processing, otherwise SAVE will not be able to determine correct result.
 
 // FixMe: specify options here 
 To check that the warning is correct for SAVE - your static analyzer must print the result to stderr/stdout or to some log file.

--- a/examples/highlevel/suite1/save.toml
+++ b/examples/highlevel/suite1/save.toml
@@ -15,6 +15,8 @@ warningTextHasColumn = true
 warningTextHasLine = true
 
 [fix]
-exec_flags="-p"
-testFilePattern="*Test.kt"
-expectedFilePattern="*Expected.kt"
+execFlags="-p"
+resourceNameTestSuffix="Test"
+resourceNameExpectedSuffix="Expected"
+# testFilePattern="*Test.kt"
+# expectedFilePattern="*Expected.kt"

--- a/examples/highlevel/suite1/subSuite/save.toml
+++ b/examples/highlevel/suite1/subSuite/save.toml
@@ -4,7 +4,7 @@ description = "My suite description"
 suiteName = "DocsCheck"
 
 [warn]
-execCmd = "./detekt --build-upon-default-config -i"
+execFlags = "./detekt --build-upon-default-config -i"
 warningsInputPattern = "// ;warn:(\\d+):(\\d+): (.*)"  # warning is set inside the comment in code, `//` marks comment start in Java
 warningsOutputPattern = "\\w+ - (\\d+)/(\\d+) - (.*)$"  # e.g. `WARN - 10/14 - Class name is in incorrect case`
 lineCaptureGroup = 1  # index of regex capture group for line number, used when `warningTextHasLine: false`

--- a/examples/highlevel/suite2/inner/save.toml
+++ b/examples/highlevel/suite2/inner/save.toml
@@ -1,10 +1,12 @@
 [general]
-exec_cmd="./ktlint -R diktat-0.4.2.jar"
+execCmd="./ktlint -R diktat-0.4.2.jar"
 tags = "mytags"
 description = "My suite description"
 suiteName = "DocsCheck"
 
 [fix]
-exec_flags="-F"
-testFilePattern="*Test.kt"
-expectedFilePattern="*Expected.kt"
+execFlags="-F"
+resourceNameTestSuffix="Test"
+resourceNameExpectedSuffix="Expected"
+# testFilePattern="*Test.kt"
+# expectedFilePattern="*Expected.kt"

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/logging/Logger.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/logging/Logger.kt
@@ -14,7 +14,7 @@ import kotlinx.datetime.toLocalDateTime
 /**
  * Is debug logging enabled
  */
-var isDebugEnabled: Boolean = false
+var isDebugEnabled: Boolean = true
 
 /**
  * Whether to add time stamps to log messages

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/logging/Logger.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/logging/Logger.kt
@@ -14,7 +14,7 @@ import kotlinx.datetime.toLocalDateTime
 /**
  * Is debug logging enabled
  */
-var isDebugEnabled: Boolean = true
+var isDebugEnabled: Boolean = false
 
 /**
  * Whether to add time stamps to log messages

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
@@ -11,12 +11,12 @@ import okio.Path
 /**
  * Plugin that can be injected into SAVE during execution. Plugins accept contents of configuration file and then perform some work.
  * @property testConfig
- * @property collectStdOut
+ * @property useInternalRedirections whether to redirect stdout/stderr for internal purposes
  */
 abstract class Plugin(
     open val testConfig: TestConfig,
     private val testFiles: List<String>,
-    protected val collectStdOut: Boolean) {
+    protected val useInternalRedirections: Boolean) {
     private val fs = FileSystem.SYSTEM
 
     /**

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
@@ -11,8 +11,12 @@ import okio.Path
 /**
  * Plugin that can be injected into SAVE during execution. Plugins accept contents of configuration file and then perform some work.
  * @property testConfig
+ * @property collectStdOut
  */
-abstract class Plugin(open val testConfig: TestConfig, private val testFiles: List<String>) {
+abstract class Plugin(
+    open val testConfig: TestConfig,
+    private val testFiles: List<String>,
+    protected val collectStdOut: Boolean) {
     private val fs = FileSystem.SYSTEM
 
     /**

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
@@ -4,6 +4,7 @@ import org.cqfn.save.core.config.TestConfig
 import org.cqfn.save.core.config.isSaveTomlConfig
 import org.cqfn.save.core.files.findDescendantDirectoriesBy
 import org.cqfn.save.core.result.TestResult
+import org.cqfn.save.core.utils.ProcessBuilder
 
 import okio.FileSystem
 import okio.Path
@@ -16,8 +17,13 @@ import okio.Path
 abstract class Plugin(
     open val testConfig: TestConfig,
     private val testFiles: List<String>,
-    protected val useInternalRedirections: Boolean) {
+    private val useInternalRedirections: Boolean) {
     private val fs = FileSystem.SYSTEM
+
+    /**
+     * Instance that is capable of executing processes
+     */
+    val pb = ProcessBuilder(useInternalRedirections)
 
     /**
      * Perform plugin's work.

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessBuilder.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessBuilder.kt
@@ -160,7 +160,7 @@ class ProcessBuilder {
             val listOfCommands = if (separator != "") command.split(separator) as MutableList<String> else mutableListOf(command)
             listOfCommands.forEachIndexed { index, cmd ->
                 if (cmd.contains("echo")) {
-                    var newEchoCommand = cmd.trim(' ').replace("echo ", " echo | set /p=\"")
+                    var newEchoCommand = cmd.trim(' ').replace("echo ", " echo | set /p dummyName=\"")
                     // Now we need to add closing `"` in proper place
                     // Despite the fact, that we don't expect user redirections, for out internal tests we use them,
                     // so we need to process such cases

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessBuilder.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessBuilder.kt
@@ -43,9 +43,11 @@ expect class ProcessBuilderInternal(
 
 /**
  * Class contains common logic for all platforms
+ *
+ * @property useInternalRedirections whether to collect output for future usage, if false, [redirectTo] will be ignored
  */
 @Suppress("INLINE_CLASS_CAN_BE_USED")
-class ProcessBuilder {
+class ProcessBuilder(private val useInternalRedirections: Boolean) {
     /**
      * Singleton that describes the current file system
      */
@@ -56,7 +58,6 @@ class ProcessBuilder {
      *
      * @param command executable command with arguments
      * @param redirectTo a file where process output should be redirected. If null, output will be returned as [ExecutionResult.stdout].
-     * @param useInternalRedirections whether to collect output for future usage, if false, [redirectTo] will be ignored
      * @return [ExecutionResult] built from process output
      */
     @Suppress(
@@ -65,8 +66,7 @@ class ProcessBuilder {
         "ReturnCount")
     fun exec(
         command: String,
-        redirectTo: Path?,
-        useInternalRedirections: Boolean = true): ExecutionResult {
+        redirectTo: Path?): ExecutionResult {
         if (command.isBlank()) {
             return returnWithError("Command couldn't be empty!")
         }

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessBuilder.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessBuilder.kt
@@ -22,7 +22,7 @@ import kotlinx.datetime.Clock
 expect class ProcessBuilderInternal(
     stdoutFile: Path,
     stderrFile: Path,
-    collectStdout: Boolean) {
+    useInternalRedirections: Boolean) {
     /**
      * Modify execution command according behavior of different OS,
      * also stdout and stderr will be redirected to tmp files
@@ -56,7 +56,7 @@ class ProcessBuilder {
      *
      * @param command executable command with arguments
      * @param redirectTo a file where process output should be redirected. If null, output will be returned as [ExecutionResult.stdout].
-     * @param collectStdout whether to collect stdout for future usage, if false, [redirectTo] will be ignored
+     * @param useInternalRedirections whether to collect output for future usage, if false, [redirectTo] will be ignored
      * @return [ExecutionResult] built from process output
      */
     @Suppress(
@@ -66,10 +66,15 @@ class ProcessBuilder {
     fun exec(
         command: String,
         redirectTo: Path?,
-        collectStdout: Boolean = true): ExecutionResult {
+        useInternalRedirections: Boolean = true): ExecutionResult {
         if (command.isBlank()) {
             return returnWithError("Command couldn't be empty!")
         }
+        if (command.contains(">") && useInternalRedirections) {
+            logError("Found user provided redirections in `$command`. " +
+                    "SAVE will create own redirections for internal purpose, please refuse redirects or use corresponding argument [redirectTo]")
+        }
+
         // Temporary directory for stderr and stdout (posix `system()` can't separate streams, so we do it ourselves)
         val tmpDir = (FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
                 ("ProcessBuilder_" + Clock.System.now().toEpochMilliseconds()).toPath())
@@ -78,15 +83,11 @@ class ProcessBuilder {
         // Path to stderr file
         val stderrFile = tmpDir / "stderr.txt"
         // Instance, containing platform-dependent realization of command execution
-        val processBuilderInternal = ProcessBuilderInternal(stdoutFile, stderrFile, collectStdout)
+        val processBuilderInternal = ProcessBuilderInternal(stdoutFile, stderrFile, useInternalRedirections)
         fs.createDirectories(tmpDir)
         fs.createFile(stdoutFile)
         fs.createFile(stderrFile)
         logDebug("Created temp directory $tmpDir for stderr and stdout of ProcessBuilder")
-        if (command.contains(">")) {
-            logWarn("Found user provided redirections in `$command`. " +
-                    "SAVE uses own redirections for internal purpose and will redirect all streams to $tmpDir")
-        }
         val commandWithEcho = if (isCurrentOsWindows()) {
             processCommandWithEcho(command)
         } else {

--- a/save-common/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
+++ b/save-common/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
@@ -6,6 +6,7 @@ package org.cqfn.save.core
 
 import org.cqfn.save.core.utils.ProcessBuilder
 import org.cqfn.save.core.utils.ProcessBuilder.Companion.processCommandWithEcho
+import org.cqfn.save.core.utils.isCurrentOsWindows
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -27,6 +28,28 @@ class ProcessBuilderTest {
         val expectedCode = 0
         val expectedStdout = listOf("something")
         val expectedStderr: List<String> = emptyList()
+        assertEquals(expectedCode, actualResult.code)
+        assertEquals(expectedStdout, actualResult.stdout)
+        assertEquals(expectedStderr, actualResult.stderr)
+    }
+
+    @Test
+    @Suppress("SAY_NO_TO_VAR")
+    fun `check stdout with redirection`() {
+        val actualResult = processBuilder.exec("echo something >/dev/null", null)
+        var expectedCode: Int
+        val expectedStdout: List<String> = emptyList()
+        lateinit var expectedStderr: List<String>
+        when {
+            isCurrentOsWindows() -> {
+                expectedCode = 1
+                expectedStderr = listOf("The system cannot find the path specified.")
+            }
+            else -> {
+                expectedCode = 0
+                expectedStderr = emptyList()
+            }
+        }
         assertEquals(expectedCode, actualResult.code)
         assertEquals(expectedStdout, actualResult.stdout)
         assertEquals(expectedStderr, actualResult.stderr)

--- a/save-common/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
+++ b/save-common/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertEquals
 
 @Suppress("INLINE_CLASS_CAN_BE_USED", "LOCAL_VARIABLE_EARLY_DECLARATION")
 class ProcessBuilderTest {
-    private val processBuilder = ProcessBuilder()
+    private val processBuilder = ProcessBuilder(useInternalRedirections = true)
 
     @Test
     fun `empty command`() {

--- a/save-common/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
+++ b/save-common/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
@@ -6,7 +6,6 @@ package org.cqfn.save.core
 
 import org.cqfn.save.core.utils.ProcessBuilder
 import org.cqfn.save.core.utils.ProcessBuilder.Companion.processCommandWithEcho
-import org.cqfn.save.core.utils.isCurrentOsWindows
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -25,7 +24,7 @@ class ProcessBuilderTest {
     @Test
     fun `check stdout`() {
         val actualResult = processBuilder.exec("echo something", null)
-        val expectedCode = if (isCurrentOsWindows()) 1 else 0
+        val expectedCode = 0
         val expectedStdout = listOf("something")
         val expectedStderr: List<String> = emptyList()
         assertEquals(expectedCode, actualResult.code)
@@ -42,63 +41,63 @@ class ProcessBuilderTest {
     @Test
     fun `simple check`() {
         val inputCommand = "echo something"
-        val expectedCommand = "echo | set /p=\"something\""
+        val expectedCommand = "echo | set /p dummyName=\"something\""
         assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 
     @Test
     fun `simple check with redirection`() {
         val inputCommand = "echo something > /dev/null"
-        val expectedCommand = "echo | set /p=\"something\" > /dev/null"
+        val expectedCommand = "echo | set /p dummyName=\"something\" > /dev/null"
         assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 
     @Test
     fun `simple check with redirection without first whitespace`() {
         val inputCommand = "echo something> /dev/null"
-        val expectedCommand = "echo | set /p=\"something\" > /dev/null"
+        val expectedCommand = "echo | set /p dummyName=\"something\" > /dev/null"
         assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 
     @Test
     fun `simple check with redirection without whitespaces at all`() {
         val inputCommand = "echo something>/dev/null"
-        val expectedCommand = "echo | set /p=\"something\" >/dev/null"
+        val expectedCommand = "echo | set /p dummyName=\"something\" >/dev/null"
         assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 
     @Test
     fun `one long echo`() {
         val inputCommand = "echo stub STUB stub foo bar "
-        val expectedCommand = "echo | set /p=\"stub STUB stub foo bar\""
+        val expectedCommand = "echo | set /p dummyName=\"stub STUB stub foo bar\""
         assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 
     @Test
     fun `change multiple echo commands with redirections`() {
         val inputCommand = "echo a > /dev/null && echo b 2>/dev/null && ls"
-        val expectedCommand = "echo | set /p=\"a\" > /dev/null && echo | set /p=\"b\" 2>/dev/null && ls"
+        val expectedCommand = "echo | set /p dummyName=\"a\" > /dev/null && echo | set /p dummyName=\"b\" 2>/dev/null && ls"
         assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 
     @Test
     fun `change multiple echo commands with redirections 2`() {
         val inputCommand = "echo a > /dev/null ; echo b 2>/dev/null ; ls"
-        val expectedCommand = "echo | set /p=\"a\" > /dev/null ; echo | set /p=\"b\" 2>/dev/null ; ls"
+        val expectedCommand = "echo | set /p dummyName=\"a\" > /dev/null ; echo | set /p dummyName=\"b\" 2>/dev/null ; ls"
         assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 
     @Test
     fun `change multiple echo commands with redirections 3`() {
         val inputCommand = "echo a > /dev/null; echo b 2>/dev/null; ls"
-        val expectedCommand = "echo | set /p=\"a\" > /dev/null ; echo | set /p=\"b\" 2>/dev/null ; ls"
+        val expectedCommand = "echo | set /p dummyName=\"a\" > /dev/null ; echo | set /p dummyName=\"b\" 2>/dev/null ; ls"
         assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 
     @Test
     fun `extra whitespaces shouldn't influence to echo`() {
         val inputCommand = "echo foo bar ; echo b; ls"
-        val expectedCommand = "echo | set /p=\"foo bar\"  ; echo | set /p=\"b\"  ; ls"
+        val expectedCommand = "echo | set /p dummyName=\"foo bar\"  ; echo | set /p dummyName=\"b\"  ; ls"
         assertEquals(expectedCommand, processCommandWithEcho(inputCommand))
     }
 }

--- a/save-common/src/jvmMain/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternal.kt
+++ b/save-common/src/jvmMain/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternal.kt
@@ -13,7 +13,7 @@ import java.io.InputStreamReader
 actual class ProcessBuilderInternal actual constructor(
     private val stdoutFile: Path,
     private val stderrFile: Path,
-    private val collectStdout: Boolean
+    private val useInternalRedirections: Boolean
 ) {
     @OptIn(ExperimentalStdlibApi::class)
     actual fun prepareCmd(command: String): String {
@@ -42,7 +42,7 @@ actual class ProcessBuilderInternal actual constructor(
         process: Process,
         stream: String,
         file: Path) {
-        if (!collectStdout && stream == "stdout") {
+        if (!useInternalRedirections) {
             return
         }
         val br = BufferedReader(

--- a/save-common/src/jvmTest/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternalTest.kt
+++ b/save-common/src/jvmTest/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternalTest.kt
@@ -13,27 +13,6 @@ class ProcessBuilderInternalTest {
     private val processBuilder = ProcessBuilder()
 
     @Test
-    fun `check stdout with redirection`() {
-        val actualResult = processBuilder.exec("echo something >/dev/null", null)
-        var expectedCode: Int
-        val expectedStdout: List<String> = emptyList()
-        lateinit var expectedStderr: List<String>
-        when {
-            isCurrentOsWindows() -> {
-                expectedCode = 1
-                expectedStderr = listOf("The system cannot find the path specified.")
-            }
-            else -> {
-                expectedCode = 0
-                expectedStderr = emptyList()
-            }
-        }
-        assertEquals(expectedCode, actualResult.code)
-        assertEquals(expectedStdout, actualResult.stdout)
-        assertEquals(expectedStderr, actualResult.stderr)
-    }
-
-    @Test
     fun `check stderr`() {
         val actualResult = processBuilder.exec("cd non_existent_dir", null)
         val expectedStdout: List<String> = emptyList()

--- a/save-common/src/jvmTest/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternalTest.kt
+++ b/save-common/src/jvmTest/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternalTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertEquals
     "MISSING_KDOC_ON_FUNCTION"
 )
 class ProcessBuilderInternalTest {
-    private val processBuilder = ProcessBuilder()
+    private val processBuilder = ProcessBuilder(useInternalRedirections = true)
 
     @Test
     fun `check stderr`() {

--- a/save-common/src/nativeMain/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternal.kt
+++ b/save-common/src/nativeMain/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternal.kt
@@ -12,12 +12,12 @@ import platform.posix.system
 actual class ProcessBuilderInternal actual constructor(
     private val stdoutFile: Path,
     private val stderrFile: Path,
-    private val collectStdout: Boolean
+    private val useInternalRedirections: Boolean
 ) {
-    actual fun prepareCmd(command: String) = if (collectStdout) {
+    actual fun prepareCmd(command: String) = if (useInternalRedirections) {
         "($command) >$stdoutFile 2>$stderrFile"
     } else {
-        "($command) 2>$stderrFile"
+        command
     }
 
     actual fun exec(cmd: String): Int {

--- a/save-common/src/nativeMain/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternal.kt
+++ b/save-common/src/nativeMain/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternal.kt
@@ -15,9 +15,9 @@ actual class ProcessBuilderInternal actual constructor(
     private val collectStdout: Boolean
 ) {
     actual fun prepareCmd(command: String) = if (collectStdout) {
-        "$command >$stdoutFile 2>$stderrFile"
+        "($command) >$stdoutFile 2>$stderrFile"
     } else {
-        "$command 2>$stderrFile"
+        "($command) 2>$stderrFile"
     }
 
     actual fun exec(cmd: String): Int {

--- a/save-common/src/nativeTest/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternalTest.kt
+++ b/save-common/src/nativeTest/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternalTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 
 @Suppress("LOCAL_VARIABLE_EARLY_DECLARATION", "SAY_NO_TO_VAR")
 class ProcessBuilderInternalTest {
-    private val processBuilder = ProcessBuilder()
+    private val processBuilder = ProcessBuilder(useInternalRedirections = true)
 
     @Test
     fun `check stderr`() {

--- a/save-common/src/nativeTest/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternalTest.kt
+++ b/save-common/src/nativeTest/kotlin/org/cqfn/save/core/utils/ProcessBuilderInternalTest.kt
@@ -8,17 +8,6 @@ class ProcessBuilderInternalTest {
     private val processBuilder = ProcessBuilder()
 
     @Test
-    fun `check stdout with redirection`() {
-        val actualResult = processBuilder.exec("echo something >/dev/null", null)
-        val expectedCode = if (isCurrentOsWindows()) 1 else 0
-        val expectedStdout = listOf("something")
-        val expectedStderr: List<String> = emptyList()
-        assertEquals(expectedCode, actualResult.code)
-        assertEquals(expectedStdout, actualResult.stdout)
-        assertEquals(expectedStderr, actualResult.stderr)
-    }
-
-    @Test
     fun `check stderr`() {
         val actualResult = processBuilder.exec("cd non_existent_dir", null)
         val expectedStdout: List<String> = emptyList()
@@ -53,11 +42,11 @@ class ProcessBuilderInternalTest {
         when (getCurrentOs()) {
             CurrentOs.LINUX -> {
                 expectedCode = 512
-                expectedStderr = listOf("sh: 1: cd: can't cd to non_existent_dir")
+                expectedStderr = emptyList()
             }
             CurrentOs.MACOS -> {
                 expectedCode = 256
-                expectedStderr = listOf("sh: line 0: cd: non_existent_dir: No such file or directory")
+                expectedStderr = emptyList()
             }
             CurrentOs.WINDOWS -> {
                 expectedCode = 1

--- a/save-core/src/commonMain/kotlin/org/cqfn/save/core/Save.kt
+++ b/save-core/src/commonMain/kotlin/org/cqfn/save/core/Save.kt
@@ -92,8 +92,8 @@ class Save(
         logInfo("=> Executing plugin: ${plugin::class.simpleName} for [${plugin.testConfig.location}]")
         reporter.onPluginExecutionStart(plugin)
         try {
-            val events = plugin.execute()
-            if (events.toList().isEmpty()) {
+            val events = plugin.execute().toList()
+            if (events.isEmpty()) {
                 logInfo("No resources discovered for ${plugin::class.simpleName} in [${plugin.testConfig.location}], skipping")
                 reporter.onPluginExecutionSkip(plugin)
             }

--- a/save-plugins/fix-plugin/README.md
+++ b/save-plugins/fix-plugin/README.md
@@ -38,12 +38,12 @@ language=kotlin
 `save.toml`:
 ```toml
 [general]
-exec_cmd="./ktlint -R diktat-0.4.2.jar"
+execCmd="./ktlint -R diktat-0.4.2.jar"
 description = "My suite description"
 suiteName = "DocsCheck"
 
 [fix]
-exec_flags="-F"
+execFlags="-F"
 testFilePattern="*Test.kt"
 expectedFilePattern="*Expected.kt"
 batchMode = false
@@ -52,7 +52,7 @@ resourceNameExpectedSuffix = "Expected" #(default value)
 ```
 
 When executed from project root (where `save.propertes` is located), SAVE will cd to `rootDir` and discover all pairs of files
-matching `testFilePattern` and `expectedFilePattern` with same prefix. It will then execute `$exec_cmd $testFile` (since we specified
+matching `testFilePattern` and `expectedFilePattern` with same prefix. It will then execute `$execCmd $testFile` (since we specified
 `batchMode = false`, it will provide inputs one by one) and compare its stdout (as per `output` option) with respecting `$expectedFile`.
 Results will be written in plain text as well as JSON.
 `resourceNameTestSuffix` must include suffix name of the test file. `resourceNameExpectedSuffix` must include suffix name of the expected file.

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -51,7 +51,7 @@ class FixPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) :
             .map { it.first() to it.last() }
             .map { (expected, test) ->
                 val testCopy = createTestFile(test)
-                val execCmd = "${(generalConfig?.execCmd ?: "")} ${fixPluginConfig.execFlags} $testCopy"
+                val execCmd = "${(generalConfig!!.execCmd)} ${fixPluginConfig.execFlags} $testCopy"
                 val executionResult = pb.exec(execCmd, null, false)
                 val fixedLines = FileSystem.SYSTEM.readLines(testCopy)
                 val expectedLines = FileSystem.SYSTEM.readLines(expected)

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -28,10 +28,10 @@ import okio.Path
 class FixPlugin(
     testConfig: TestConfig,
     testFiles: List<String> = emptyList(),
-    collectStdOut: Boolean = true) : Plugin(
+    useInternalRedirections: Boolean = true) : Plugin(
     testConfig,
     testFiles,
-    collectStdOut) {
+    useInternalRedirections) {
     private val fs = FileSystem.SYSTEM
     private val pb = ProcessBuilder()
     private val diffGenerator = DiffRowGenerator.create()
@@ -59,7 +59,7 @@ class FixPlugin(
             .map { (expected, test) ->
                 val testCopy = createTestFile(test)
                 val execCmd = "${(generalConfig!!.execCmd)} ${fixPluginConfig.execFlags} $testCopy"
-                val executionResult = pb.exec(execCmd, null, collectStdOut)
+                val executionResult = pb.exec(execCmd, null, useInternalRedirections)
                 val stdout = executionResult.stdout.joinToString("\n")
                 val stderr = executionResult.stderr.joinToString("\n")
 

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -25,7 +25,13 @@ import okio.Path
  * @property testConfig
  */
 @Suppress("INLINE_CLASS_CAN_BE_USED")
-class FixPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) : Plugin(testConfig, testFiles) {
+class FixPlugin(
+    testConfig: TestConfig,
+    testFiles: List<String> = emptyList(),
+    collectStdOut: Boolean = true) : Plugin(
+    testConfig,
+    testFiles,
+    collectStdOut) {
     private val fs = FileSystem.SYSTEM
     private val pb = ProcessBuilder()
     private val diffGenerator = DiffRowGenerator.create()
@@ -53,7 +59,7 @@ class FixPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) :
             .map { (expected, test) ->
                 val testCopy = createTestFile(test)
                 val execCmd = "${(generalConfig!!.execCmd)} ${fixPluginConfig.execFlags} $testCopy"
-                val executionResult = pb.exec(execCmd, null, false)
+                val executionResult = pb.exec(execCmd, null, collectStdOut)
                 val stdout = executionResult.stdout.joinToString("\n")
                 val stderr = executionResult.stderr.joinToString("\n")
 

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -11,7 +11,6 @@ import org.cqfn.save.core.result.DebugInfo
 import org.cqfn.save.core.result.Fail
 import org.cqfn.save.core.result.Pass
 import org.cqfn.save.core.result.TestResult
-import org.cqfn.save.core.utils.ProcessBuilder
 
 import io.github.petertrr.diffutils.diff
 import io.github.petertrr.diffutils.patch.ChangeDelta
@@ -33,7 +32,6 @@ class FixPlugin(
     testFiles,
     useInternalRedirections) {
     private val fs = FileSystem.SYSTEM
-    private val pb = ProcessBuilder()
     private val diffGenerator = DiffRowGenerator.create()
         .showInlineDiffs(true)
         .mergeOriginalRevised(false)
@@ -59,7 +57,7 @@ class FixPlugin(
             .map { (expected, test) ->
                 val testCopy = createTestFile(test)
                 val execCmd = "${(generalConfig!!.execCmd)} ${fixPluginConfig.execFlags} $testCopy"
-                val executionResult = pb.exec(execCmd, null, useInternalRedirections)
+                val executionResult = pb.exec(execCmd, null)
                 val stdout = executionResult.stdout.joinToString("\n")
                 val stderr = executionResult.stderr.joinToString("\n")
 

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -63,9 +63,7 @@ class FixPlugin(
 
                 val fixedLines = FileSystem.SYSTEM.readLines(testCopy)
                 val expectedLines = FileSystem.SYSTEM.readLines(expected)
-                val status = if (executionResult.code != 0) {
-                    Fail(stderr)
-                } else {
+                val status = if (executionResult.code == 0) {
                     diff(expectedLines, fixedLines).let { patch ->
                         if (patch.deltas.isEmpty()) {
                             Pass(null)
@@ -73,6 +71,8 @@ class FixPlugin(
                             Fail(patch.formatToString())
                         }
                     }
+                } else {
+                    Fail(stderr)
                 }
                 TestResult(
                     listOf(expected, test),

--- a/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
+++ b/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
@@ -88,7 +88,8 @@ class FixPluginTest {
         )).execute()
 
         assertEquals(1, results.count(), "Size of results should equal number of pairs")
-        assertEquals(TestResult(listOf(expectedFile, testFile), Pass(null), DebugInfo(results.single().debugInfo?.stdout, results.single().debugInfo?.stderr, null)), results.single())
+        assertEquals(TestResult(listOf(expectedFile, testFile), Pass(null),
+            DebugInfo(results.single().debugInfo?.stdout, results.single().debugInfo?.stderr, null)), results.single())
         val tmpDir = (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / FixPlugin::class.simpleName!!)
         assertTrue("Files should be identical") {
             diff(fs.readLines(tmpDir / "Test3Test.java"), fs.readLines(expectedFile))

--- a/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
+++ b/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
@@ -88,7 +88,7 @@ class FixPluginTest {
         )).execute()
 
         assertEquals(1, results.count(), "Size of results should equal number of pairs")
-        assertEquals(TestResult(listOf(expectedFile, testFile), Pass(null), DebugInfo(results.single().debugInfo?.stdout, null, null)), results.single())
+        assertEquals(TestResult(listOf(expectedFile, testFile), Pass(null), DebugInfo(results.single().debugInfo?.stdout, results.single().debugInfo?.stderr, null)), results.single())
         val tmpDir = (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / FixPlugin::class.simpleName!!)
         assertTrue("Files should be identical") {
             diff(fs.readLines(tmpDir / "Test3Test.java"), fs.readLines(expectedFile))

--- a/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
+++ b/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
@@ -33,7 +33,7 @@ class FixPluginTest {
         fs.createFile(tmpDir / "Test1Test.java")
         fs.createFile(tmpDir / "Test1Expected.java")
 
-        val pairs = FixPlugin(TestConfig(tmpDir / "Test1Test.java", null, mutableListOf(FixPluginConfig(""))))
+        val pairs = FixPlugin(TestConfig(tmpDir / "Test1Test.java", null, mutableListOf(FixPluginConfig(""))), collectStdOut = false)
             .discoverTestFiles(tmpDir)
             .map { it.first() to it.last() }
             .toList()
@@ -55,7 +55,7 @@ class FixPluginTest {
         fs.createFile(tmpDir / "NowCompletelyDifferentExpected.java")
         fs.createFile(tmpDir / "AndNowCompletelyDifferent.java")
 
-        val pairs = FixPlugin(TestConfig(tmpDir / "Something.java", null, mutableListOf(FixPluginConfig(""))))
+        val pairs = FixPlugin(TestConfig(tmpDir / "Something.java", null, mutableListOf(FixPluginConfig(""))), collectStdOut = false)
             .discoverTestFiles(tmpDir)
             .map { it.first() to it.last() }
             .toList()
@@ -85,7 +85,7 @@ class FixPluginTest {
                 FixPluginConfig(executionCmd),
                 GeneralConfig("", "", "", "")
             )
-        )).execute()
+        ), collectStdOut = false).execute()
 
         assertEquals(1, results.count(), "Size of results should equal number of pairs")
         assertEquals(TestResult(listOf(expectedFile, testFile), Pass(null),

--- a/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
+++ b/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
@@ -33,7 +33,7 @@ class FixPluginTest {
         fs.createFile(tmpDir / "Test1Test.java")
         fs.createFile(tmpDir / "Test1Expected.java")
 
-        val pairs = FixPlugin(TestConfig(tmpDir / "Test1Test.java", null, mutableListOf(FixPluginConfig(""))), collectStdOut = false)
+        val pairs = FixPlugin(TestConfig(tmpDir / "Test1Test.java", null, mutableListOf(FixPluginConfig(""))), useInternalRedirections = false)
             .discoverTestFiles(tmpDir)
             .map { it.first() to it.last() }
             .toList()
@@ -55,7 +55,7 @@ class FixPluginTest {
         fs.createFile(tmpDir / "NowCompletelyDifferentExpected.java")
         fs.createFile(tmpDir / "AndNowCompletelyDifferent.java")
 
-        val pairs = FixPlugin(TestConfig(tmpDir / "Something.java", null, mutableListOf(FixPluginConfig(""))), collectStdOut = false)
+        val pairs = FixPlugin(TestConfig(tmpDir / "Something.java", null, mutableListOf(FixPluginConfig(""))), useInternalRedirections = false)
             .discoverTestFiles(tmpDir)
             .map { it.first() to it.last() }
             .toList()
@@ -85,7 +85,7 @@ class FixPluginTest {
                 FixPluginConfig(executionCmd),
                 GeneralConfig("", "", "", "")
             )
-        ), collectStdOut = false).execute()
+        ), useInternalRedirections = false).execute()
 
         assertEquals(1, results.count(), "Size of results should equal number of pairs")
         assertEquals(TestResult(listOf(expectedFile, testFile), Pass(null),

--- a/save-plugins/warn-plugin/README.md
+++ b/save-plugins/warn-plugin/README.md
@@ -83,7 +83,7 @@ testNameSuffix = "Test" # (default value)
 ```
 
 When executed from project root (where `save.propertes` is located), SAVE will cd to `rootDir` and discover all files
-matching `inputFilePattern`. It will then execute `$exec_cmd $testFile` (since we specified
+matching `inputFilePattern`. It will then execute `$execCmd $testFile` (since we specified
 `batchMode = false`, it will provide inputs one by one) and compare warnings its stdout (as per `output` option) parsed using `warningsOutputPattern` with warnings
 parsed from the same `$testFile` using `warningsInputPattern`.
 

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -95,7 +95,7 @@ class WarnPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) 
             val fileName = createTestFile(path, warnPluginConfig.warningsInputPattern!!)
             "${generalConfig.execCmd} ${warnPluginConfig.execFlags} $fileName"
         } else {
-            "${(generalConfig.execCmd)} ${warnPluginConfig.execFlags} ${path.name}"
+            "${(generalConfig.execCmd)} ${warnPluginConfig.execFlags} $path"
         }
 
         val executionResult = pb.exec(execCmd, null)
@@ -126,8 +126,8 @@ class WarnPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) 
 
         createTempDir(tmpDir)
 
-        val fileName = testFileName()
-        fs.write(fs.createFile(tmpDir / fileName)) {
+        val fileName = tmpDir / testFileName()
+        fs.write(fs.createFile(fileName)) {
             fs.readLines(path).forEach {
                 if (!warningsInputPattern.matches(it)) {
                     write(
@@ -136,7 +136,7 @@ class WarnPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) 
                 }
             }
         }
-        return fileName
+        return fileName.toString()
     }
 
     @Suppress("TYPE_ALIAS")

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -99,6 +99,9 @@ class WarnPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) 
         }
 
         val executionResult = pb.exec(execCmd, null)
+        val stdout = executionResult.stdout.joinToString("\n")
+        val stderr = executionResult.stderr.joinToString("\n")
+        val status = if (executionResult.code != 0) Fail(stderr) else null
         val actualWarningsMap = executionResult.stdout.mapNotNull {
             with(warnPluginConfig) {
                 it.extractWarning(warningsOutputPattern!!, columnCaptureGroup, lineCaptureGroup, messageCaptureGroup!!)
@@ -108,8 +111,8 @@ class WarnPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) 
             .mapValues { (_, warning) -> warning.sortedBy { it.message } }
         return TestResult(
             listOf(path),
-            checkResults(expectedWarnings, actualWarningsMap, warnPluginConfig),
-            DebugInfo(executionResult.stdout.joinToString("\n"), executionResult.stderr.joinToString("\n"), null)
+            status ?: checkResults(expectedWarnings, actualWarningsMap, warnPluginConfig),
+            DebugInfo(stdout, stderr, null)
         )
     }
 

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -25,7 +25,13 @@ private typealias LineColumn = Pair<Int, Int>
  * A plugin that runs an executable and verifies that it produces required warning messages.
  * @property testConfig
  */
-class WarnPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) : Plugin(testConfig, testFiles) {
+class WarnPlugin(
+    testConfig: TestConfig,
+    testFiles: List<String> = emptyList(),
+    collectStdOut: Boolean = true) : Plugin(
+    testConfig,
+    testFiles,
+    collectStdOut) {
     private val fs = FileSystem.SYSTEM
     private val pb = ProcessBuilder()
 
@@ -98,7 +104,7 @@ class WarnPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) 
             "${(generalConfig.execCmd)} ${warnPluginConfig.execFlags} $path"
         }
 
-        val executionResult = pb.exec(execCmd, null)
+        val executionResult = pb.exec(execCmd, null, collectStdOut)
         val stdout = executionResult.stdout.joinToString("\n")
         val stderr = executionResult.stderr.joinToString("\n")
         val status = if (executionResult.code != 0) Fail(stderr) else null

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -102,7 +102,7 @@ class WarnPlugin(
         }
 
         val fileNames = paths.joinToString {
-            if (generalConfig!!.ignoreSaveComments == true) createTestFile(it, warnPluginConfig.warningsInputPattern!!) else it.name
+            if (generalConfig!!.ignoreSaveComments == true) createTestFile(it, warnPluginConfig.warningsInputPattern!!) else it.toString()
         }
         val execCmd = "${generalConfig!!.execCmd} ${warnPluginConfig.execFlags} $fileNames"
 

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -91,11 +91,11 @@ class WarnPlugin(testConfig: TestConfig, testFiles: List<String> = emptyList()) 
             }
             .mapValues { it.value.sortedBy { it.message } }
 
-        val execCmd: String = if (generalConfig?.ignoreSaveComments == true) {
+        val execCmd: String = if (generalConfig!!.ignoreSaveComments == true) {
             val fileName = createTestFile(path, warnPluginConfig.warningsInputPattern!!)
             "${generalConfig.execCmd} ${warnPluginConfig.execFlags} $fileName"
         } else {
-            "${(generalConfig?.execCmd ?: "")} ${warnPluginConfig.execFlags} ${path.name}"
+            "${(generalConfig.execCmd)} ${warnPluginConfig.execFlags} ${path.name}"
         }
 
         val executionResult = pb.exec(execCmd, null)

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -12,7 +12,6 @@ import org.cqfn.save.core.result.Pass
 import org.cqfn.save.core.result.TestResult
 import org.cqfn.save.core.result.TestStatus
 import org.cqfn.save.core.utils.AtomicInt
-import org.cqfn.save.core.utils.ProcessBuilder
 import org.cqfn.save.plugin.warn.utils.Warning
 import org.cqfn.save.plugin.warn.utils.extractWarning
 
@@ -33,7 +32,6 @@ class WarnPlugin(
     testFiles,
     useInternalRedirections) {
     private val fs = FileSystem.SYSTEM
-    private val pb = ProcessBuilder()
 
     override fun handleFiles(files: Sequence<List<Path>>): Sequence<TestResult> {
         val flattenedResources = files.toList().flatten()
@@ -108,7 +106,7 @@ class WarnPlugin(
         }
         val execCmd = "${generalConfig!!.execCmd} ${warnPluginConfig.execFlags} $fileNames"
 
-        val executionResult = pb.exec(execCmd, null, useInternalRedirections)
+        val executionResult = pb.exec(execCmd, null)
         val stdout = executionResult.stdout.joinToString("\n")
         val stderr = executionResult.stderr.joinToString("\n")
         val status = if (executionResult.code != 0) Fail(stderr) else null

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -28,10 +28,10 @@ private typealias LineColumn = Pair<Int, Int>
 class WarnPlugin(
     testConfig: TestConfig,
     testFiles: List<String> = emptyList(),
-    collectStdOut: Boolean = true) : Plugin(
+    useInternalRedirections: Boolean = true) : Plugin(
     testConfig,
     testFiles,
-    collectStdOut) {
+    useInternalRedirections) {
     private val fs = FileSystem.SYSTEM
     private val pb = ProcessBuilder()
 
@@ -104,7 +104,7 @@ class WarnPlugin(
             "${(generalConfig.execCmd)} ${warnPluginConfig.execFlags} $path"
         }
 
-        val executionResult = pb.exec(execCmd, null, collectStdOut)
+        val executionResult = pb.exec(execCmd, null, useInternalRedirections)
         val stdout = executionResult.stdout.joinToString("\n")
         val stderr = executionResult.stderr.joinToString("\n")
         val status = if (executionResult.code != 0) Fail(stderr) else null

--- a/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/WarnPluginTest.kt
+++ b/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/WarnPluginTest.kt
@@ -57,7 +57,7 @@ class WarnPluginTest {
                 }
             """.trimIndent(),
             WarnPluginConfig(
-                "$catCmd ${tmpDir / "resource"}",
+                "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("[\\w\\d.-]+:(\\d+):(\\d+): (.+)"),
                 true, true, 1, 2, 3
@@ -91,7 +91,7 @@ class WarnPluginTest {
                 }
             """.trimIndent(),
             WarnPluginConfig(
-                "$catCmd ${tmpDir / "resource"}",
+                "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("[\\w\\d.-]+:(\\d+):(\\d+): (.+)"),
                 true, true, 1, 2, 3, false
@@ -153,7 +153,7 @@ class WarnPluginTest {
                 // ;warn:7:1: File should end with trailing newline
             """.trimIndent(),
             WarnPluginConfig(
-                "$catCmd ${tmpDir / "resource"}",
+                "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("[\\w\\d.-]+:(\\d+):(\\d+): (.+)"),
                 true, true, 1, 2, 3
@@ -190,7 +190,7 @@ class WarnPluginTest {
                 // ;warn:3:1: File should end with trailing newline
             """.trimIndent(),
             WarnPluginConfig(
-                "$catCmd ${tmpDir / "resource"}",
+                "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("[\\w\\d.-]+:(\\d+):(\\d+): (.+)"),
                 true, true, 1, 2, 3
@@ -226,7 +226,7 @@ class WarnPluginTest {
                 // ;warn: File should end with trailing newline
             """.trimIndent(),
             WarnPluginConfig(
-                "$catCmd ${tmpDir / "resource"}",
+                "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn: (.*)"),
                 Regex("[\\w\\d.-]+: (.+)"),
                 false, false, null, null, 1
@@ -292,7 +292,7 @@ class WarnPluginTest {
 
         val catCmd = if (isCurrentOsWindows()) "type" else "cat"
         val warnPluginConfig = WarnPluginConfig(
-            "$catCmd ${tmpDir / "resource"}",
+            "$catCmd ${tmpDir / "resource"} && set stub=",
             Regex("// ;warn: (.*)"),
             Regex("[\\w\\d.-]+: (.+)"),
             false, false, null, null, 1


### PR DESCRIPTION
### What's done:
* Handle execution output from ProcessBuilder in Plugins
* Update toml example files
* Fix in ProcessBuilder native: if command is complex, all output will be redirected into one variable (fixed by adding '(' ')' in cmd)
* Change ERRORLEVEL for echo commands on Windows from 1 to 0
* Update tests