### PR TITLE
Hotfix for logic of handling ProcessBuilder results in plugins

### DIFF
--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessExecutionException.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/utils/ProcessExecutionException.kt
@@ -1,0 +1,6 @@
+package org.cqfn.save.core.utils
+
+/**
+ * An [Exception] that can be thrown in case of impossibility of command execution
+ */
+class ProcessExecutionException(message: String) : Exception(message)

--- a/save-common/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
+++ b/save-common/src/commonTest/kotlin/org/cqfn/save/core/ProcessBuilderTest.kt
@@ -6,6 +6,7 @@ package org.cqfn.save.core
 
 import org.cqfn.save.core.utils.ProcessBuilder
 import org.cqfn.save.core.utils.ProcessBuilder.Companion.processCommandWithEcho
+import org.cqfn.save.core.utils.ProcessExecutionException
 import org.cqfn.save.core.utils.isCurrentOsWindows
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -16,10 +17,11 @@ class ProcessBuilderTest {
 
     @Test
     fun `empty command`() {
-        val actualResult = processBuilder.exec(" ", null)
-        assertEquals(-1, actualResult.code)
-        assertEquals(emptyList(), actualResult.stdout)
-        assertEquals(listOf("Command couldn't be empty!"), actualResult.stderr)
+        try {
+            processBuilder.exec(" ", null)
+        } catch (ex: ProcessExecutionException) {
+            assertEquals("Command couldn't be empty!", ex.message)
+        }
     }
 
     @Test


### PR DESCRIPTION
### What's done:
* Create new type of exception for ProcessBuilder
* Now we fail in plugins in case of internal exceptions, not when exit code equals to zero