### PR TITLE
Fixes in warn-plugin

### DIFF
--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -168,10 +168,8 @@ class WarnPlugin(
     internal fun checkResults(expectedWarningsMap: Map<LineColumn?, List<Warning>>,
                               actualWarningsMap: Map<LineColumn?, List<Warning>>,
                               warnPluginConfig: WarnPluginConfig): TestStatus {
-        val missingWarnings: List<Warning> = expectedWarningsMap.values.flatten()
-            .filter { it !in actualWarningsMap.values.flatten() }
-        val unexpectedWarnings: List<Warning> = actualWarningsMap.values.flatten()
-            .filter { it !in expectedWarningsMap.values.flatten() }
+        val missingWarnings = expectedWarningsMap.valuesNotIn(actualWarningsMap)
+        val unexpectedWarnings = actualWarningsMap.valuesNotIn(expectedWarningsMap)
 
         return when (missingWarnings.isEmpty() to unexpectedWarnings.isEmpty()) {
             false to true -> Fail("Some warnings were expected but not received: $missingWarnings")
@@ -186,4 +184,14 @@ class WarnPlugin(
             else -> Fail("")
         }
     }
+}
+
+/**
+ * Collect all values that are present in [this] map, but absent in [other]
+ */
+private fun <K, V> Map<K, List<V>>.valuesNotIn(other: Map<K, List<V>>): List<V> = flatMap { (key, value) ->
+    other[key]?.let { otherValue ->
+        value.filter { it !in otherValue }
+    }
+        ?: value
 }

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -18,6 +18,7 @@ import org.cqfn.save.plugin.warn.utils.extractWarning
 import okio.FileSystem
 import okio.Path
 
+private typealias WarningMap = MutableMap<LineColumn?, List<Warning>>
 internal typealias LineColumn = Pair<Int, Int>
 
 /**
@@ -186,5 +187,3 @@ class WarnPlugin(
         }
     }
 }
-
-typealias WarningMap = MutableMap<Pair<Int, Int>?, List<Warning>>

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -11,7 +11,6 @@ import org.cqfn.save.core.result.Fail
 import org.cqfn.save.core.result.Pass
 import org.cqfn.save.core.result.TestResult
 import org.cqfn.save.core.result.TestStatus
-import org.cqfn.save.core.utils.AtomicInt
 import org.cqfn.save.core.utils.ProcessExecutionException
 import org.cqfn.save.plugin.warn.utils.Warning
 import org.cqfn.save.plugin.warn.utils.extractWarning
@@ -19,7 +18,7 @@ import org.cqfn.save.plugin.warn.utils.extractWarning
 import okio.FileSystem
 import okio.Path
 
-private typealias LineColumn = Pair<Int, Int>
+internal typealias LineColumn = Pair<Int, Int>
 
 /**
  * A plugin that runs an executable and verifies that it produces required warning messages.
@@ -143,7 +142,7 @@ class WarnPlugin(
 
         createTempDir(tmpDir)
 
-        val fileName = tmpDir / testFileName()
+        val fileName = tmpDir / path.name
         fs.write(fs.createFile(fileName)) {
             fs.readLines(path).forEach {
                 if (!warningsInputPattern.matches(it)) {
@@ -156,12 +155,22 @@ class WarnPlugin(
         return fileName.toString()
     }
 
+    /**
+     * Compares actual and expected warnings and returns TestResult
+     *
+     * @param expectedWarningsMap expected warnings, grouped by LineCol
+     * @param actualWarningsMap actual warnings, grouped by LineCol
+     * @param warnPluginConfig configuration of warn plugin
+     * @return [TestResult]
+     */
     @Suppress("TYPE_ALIAS")
-    private fun checkResults(expectedWarningsMap: Map<LineColumn?, List<Warning>>,
-                             actualWarningsMap: Map<LineColumn?, List<Warning>>,
-                             warnPluginConfig: WarnPluginConfig): TestStatus {
-        val missingWarnings = expectedWarningsMap.filterValues { it !in actualWarningsMap.values }.values
-        val unexpectedWarnings = actualWarningsMap.filterValues { it !in expectedWarningsMap.values }.values
+    internal fun checkResults(expectedWarningsMap: Map<LineColumn?, List<Warning>>,
+                              actualWarningsMap: Map<LineColumn?, List<Warning>>,
+                              warnPluginConfig: WarnPluginConfig): TestStatus {
+        val missingWarnings: List<Warning> = expectedWarningsMap.values.flatten()
+            .filter { it !in actualWarningsMap.values.flatten() }
+        val unexpectedWarnings: List<Warning> = actualWarningsMap.values.flatten()
+            .filter { it !in expectedWarningsMap.values.flatten() }
 
         return when (missingWarnings.isEmpty() to unexpectedWarnings.isEmpty()) {
             false to true -> Fail("Some warnings were expected but not received: $missingWarnings")
@@ -176,11 +185,6 @@ class WarnPlugin(
             else -> Fail("")
         }
     }
-
-    private fun testFileName(): String = "test_file${atomicInt.addAndGet(1)}"
-
-    companion object {
-        val atomicInt: AtomicInt = AtomicInt(0)
-    }
 }
+
 typealias WarningMap = MutableMap<Pair<Int, Int>?, List<Warning>>

--- a/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/WarnPluginTest.kt
+++ b/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/WarnPluginTest.kt
@@ -104,8 +104,8 @@ class WarnPluginTest {
         ) { results ->
             assertEquals(1, results.size)
             assertTrue(results.single().status is Pass)
-            val nameWarn = "Some warnings were unexpected: [[Warning(message=Variable name should be in lowerCamelCase, line=5, column=8, fileName=Test1Test.java)]]"
-            assertEquals((results.single().status as Pass).message, nameWarn)
+            val nameWarn = "Some warnings were unexpected: [Warning(message=Variable name should be in lowerCamelCase, line=5, column=8, fileName=Test1Test.java)]"
+            assertEquals(nameWarn, (results.single().status as Pass).message)
         }
         fs.delete(tmpDir / "resource")
     }

--- a/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/utils/ComparisonTest.kt
+++ b/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/utils/ComparisonTest.kt
@@ -33,6 +33,7 @@ class ComparisonTest {
     }
 
     @Test
+    @Suppress("TYPE_ALIAS")
     fun `should compare warnings`() {
         val resourceFileName = "resource"
         val expectedWarningsMap: Map<LineColumn?, List<Warning>> = mapOf(

--- a/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/utils/ComparisonTest.kt
+++ b/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/utils/ComparisonTest.kt
@@ -1,0 +1,61 @@
+package org.cqfn.save.plugin.warn.utils
+
+import org.cqfn.save.core.config.TestConfig
+import org.cqfn.save.core.files.createFile
+import org.cqfn.save.core.result.Pass
+import org.cqfn.save.plugin.warn.LineColumn
+import org.cqfn.save.plugin.warn.WarnPlugin
+import org.cqfn.save.plugin.warn.WarnPluginConfig
+
+import okio.FileSystem
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ComparisonTest {
+    private val fs = FileSystem.SYSTEM
+    private val tmpDir = (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / ComparisonTest::class.simpleName!!)
+
+    @BeforeTest
+    fun setUp() {
+        if (fs.exists(tmpDir)) {
+            fs.deleteRecursively(tmpDir)
+        }
+        fs.createDirectory(tmpDir)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        fs.deleteRecursively(tmpDir)
+    }
+
+    @Test
+    fun `should compare warnings`() {
+        val resourceFileName = "resource"
+        val expectedWarningsMap: Map<LineColumn?, List<Warning>> = mapOf(
+            (8 to 5) to listOf(
+                Warning("foo", 8, 5, resourceFileName)
+            )
+        )
+        val actualWarningsMap: Map<LineColumn?, List<Warning>> = mapOf(
+            (8 to 5) to listOf(
+                Warning("bar", 8, 5, resourceFileName),
+                Warning("baz", 8, 5, resourceFileName),
+                Warning("foo", 8, 5, resourceFileName)
+            )
+        )
+        val warnPluginConfig = WarnPluginConfig(exactWarningsMatch = false)
+        val config = fs.createFile(tmpDir / "save.toml")
+
+        val testStatus = WarnPlugin(TestConfig(config, null, mutableListOf(warnPluginConfig)))
+            .checkResults(expectedWarningsMap, actualWarningsMap, warnPluginConfig)
+
+        assertTrue(testStatus is Pass, "Actual type of status is ${testStatus::class}")
+        assertEquals(
+            "Some warnings were unexpected: ${actualWarningsMap.values.single().dropLast(1)}",
+            testStatus.message)
+    }
+}


### PR DESCRIPTION
### What's done:
* warn-plugin: retain file name when creating a copy without technical comments
* warn-plugin: fixed logic of warnings comparison
* Added tests

Closes #135 