### PR TITLE
Separator for batchMode should be configurable

### DIFF
--- a/save-core/src/commonTest/kotlin/org/cqfn/save/core/MergeConfigsTest.kt
+++ b/save-core/src/commonTest/kotlin/org/cqfn/save/core/MergeConfigsTest.kt
@@ -35,9 +35,9 @@ class MergeConfigsTest {
     private val warningsOutputPattern1 = Regex(".*")
     private val warningsOutputPattern2 = Regex("\\w+ - (\\d+)/(\\d+) - (.*)$")
     private val warnConfig1 = WarnPluginConfig("execCmd1", warningsInputPattern2, warningsOutputPattern2,
-        false, false, 1, 1, 1, 1, 1, 1, 1, 1, false)
+        false, false, 1, ", ", 1, 1, 1, 1, 1, 1, 1, false)
     private val warnConfig2 = WarnPluginConfig("execCmd2", warningsInputPattern1, warningsOutputPattern1,
-        true, true, 1, 2, 2, 2, 2, 2, 2, 2, true)
+        true, true, 1, ", ", 2, 2, 2, 2, 2, 2, 2, true)
     private val warnConfig3 = WarnPluginConfig("execCmd3", warningsInputPattern2, warningsOutputPattern2,
         warningTextHasColumn = false, batchSize = 1, lineCaptureGroup = 3, columnCaptureGroup = 3, messageCaptureGroup = 3,
         fileNameCaptureGroupOut = 3, lineCaptureGroupOut = 3, columnCaptureGroupOut = 3, messageCaptureGroupOut = 3)
@@ -114,7 +114,7 @@ class MergeConfigsTest {
 
         val expectedGeneralConfig = GeneralConfig("", "Tag11, Tag12, Tag21", "Description2", "suiteName2", "excludedTests: test3", "includedTests: test4")
         val expectedWarnConfig = WarnPluginConfig("execCmd3", warningsInputPattern2, warningsOutputPattern2,
-            true, false, 1, 3, 3, 3, 3, 3, 3, 3, true)
+            true, false, 1, ", ", 3, 3, 3, 3, 3, 3, 3, true)
         val expectedFixConfig = FixPluginConfig("fixCmd2", 1, "Suffix")
 
         val actualGeneralConfig = config2.pluginConfigs.filterIsInstance<GeneralConfig>().first()
@@ -139,7 +139,7 @@ class MergeConfigsTest {
         assertEquals(3, config4.pluginConfigs.size)
         val expectedGeneralConfig = GeneralConfig("", "Tag11, Tag12, Tag21, Tag31, Tag32", "Description2", "suiteName4", "excludedTests: test7", "includedTests: test8")
         val expectedWarnConfig = WarnPluginConfig("execCmd4", warningsInputPattern2, warningsOutputPattern2,
-            true, false, 1, 4, 4, 4, 4, 4, 4, 4, true)
+            true, false, 1, ", ", 4, 4, 4, 4, 4, 4, 4, true)
         val expectedFixConfig = FixPluginConfig("fixCmd4", 1, "Suffix")
 
         val actualGeneralConfig = config4.pluginConfigs.filterIsInstance<GeneralConfig>().first()

--- a/save-core/src/commonTest/kotlin/org/cqfn/save/core/ValidationTest.kt
+++ b/save-core/src/commonTest/kotlin/org/cqfn/save/core/ValidationTest.kt
@@ -139,7 +139,7 @@ class ValidationTest {
             assertEquals(
                 "Error: All integer values in [warn] section of `${warnConfig.configLocation}` config should be positive!" +
                         "\nCurrent configuration: execFlags=execFlags, warningsInputPattern=null, warningsOutputPattern=null, " +
-                        "warningTextHasLine=null, warningTextHasColumn=null, batchSize=null, separator=null, lineCaptureGroup=-127, columnCaptureGroup=null, " +
+                        "warningTextHasLine=null, warningTextHasColumn=null, batchSize=null, batchSeparator=null, lineCaptureGroup=-127, columnCaptureGroup=null, " +
                         "messageCaptureGroup=null, fileNameCaptureGroupOut=null, lineCaptureGroupOut=null, columnCaptureGroupOut=null, messageCaptureGroupOut=null, " +
                         "exactWarningsMatch=null, testNameSuffix=null",
                 ex.message

--- a/save-core/src/commonTest/kotlin/org/cqfn/save/core/ValidationTest.kt
+++ b/save-core/src/commonTest/kotlin/org/cqfn/save/core/ValidationTest.kt
@@ -139,7 +139,7 @@ class ValidationTest {
             assertEquals(
                 "Error: All integer values in [warn] section of `${warnConfig.configLocation}` config should be positive!" +
                         "\nCurrent configuration: execFlags=execFlags, warningsInputPattern=null, warningsOutputPattern=null, " +
-                        "warningTextHasLine=null, warningTextHasColumn=null, batchSize=null, lineCaptureGroup=-127, columnCaptureGroup=null, " +
+                        "warningTextHasLine=null, warningTextHasColumn=null, batchSize=null, separator=null, lineCaptureGroup=-127, columnCaptureGroup=null, " +
                         "messageCaptureGroup=null, fileNameCaptureGroupOut=null, lineCaptureGroupOut=null, columnCaptureGroupOut=null, messageCaptureGroupOut=null, " +
                         "exactWarningsMatch=null, testNameSuffix=null",
                 ex.message

--- a/save-plugins/fix-plugin/README.md
+++ b/save-plugins/fix-plugin/README.md
@@ -47,13 +47,13 @@ execFlags="-F"
 testFilePattern="*Test.kt"
 expectedFilePattern="*Expected.kt"
 batchSize = 1 # (default value)
-separator = ", " # (default value)
+batchSeparator = ", " # (default value)
 resourceNameTestSuffix = "Test" # (default value)
 resourceNameExpectedSuffix = "Expected" #(default value)
 ```
 
 When executed from project root (where `save.propertes` is located), SAVE will cd to `rootDir` and discover all pairs of files
 matching `testFilePattern` and `expectedFilePattern` with same prefix. It will then execute `$execCmd $testFile`. `batchSize` it controls how many files execCmd will process at a time. (since we specified
-`batchSize = 1`, it will provide inputs one by one) and compare its stdout (as per `output` option) with respecting `$expectedFile`. `separator` is a setting for batchSize.
+`batchSize = 1`, it will provide inputs one by one) and compare its stdout (as per `output` option) with respecting `$expectedFile`.  `batchSeparator` is separator for filenames in `execCmd` if `batchSize > 1`.
 Results will be written in plain text as well as JSON.
 `resourceNameTestSuffix` must include suffix name of the test file. `resourceNameExpectedSuffix` must include suffix name of the expected file.

--- a/save-plugins/fix-plugin/README.md
+++ b/save-plugins/fix-plugin/README.md
@@ -46,13 +46,14 @@ suiteName = "DocsCheck"
 execFlags="-F"
 testFilePattern="*Test.kt"
 expectedFilePattern="*Expected.kt"
-batchSize = 1
+batchSize = 1 # (default value)
+separator = ", " # (default value)
 resourceNameTestSuffix = "Test" # (default value)
 resourceNameExpectedSuffix = "Expected" #(default value)
 ```
 
 When executed from project root (where `save.propertes` is located), SAVE will cd to `rootDir` and discover all pairs of files
 matching `testFilePattern` and `expectedFilePattern` with same prefix. It will then execute `$execCmd $testFile`. `batchSize` it controls how many files execCmd will process at a time. (since we specified
-`batchSize = 1`, it will provide inputs one by one) and compare its stdout (as per `output` option) with respecting `$expectedFile`.
+`batchSize = 1`, it will provide inputs one by one) and compare its stdout (as per `output` option) with respecting `$expectedFile`. `separator` is a setting for batchSize.
 Results will be written in plain text as well as JSON.
 `resourceNameTestSuffix` must include suffix name of the test file. `resourceNameExpectedSuffix` must include suffix name of the expected file.

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -54,7 +54,7 @@ class FixPlugin(
         return files.chunked(fixPluginConfig.batchSize!!).map { chunk ->
             val pathMap = chunk.map { it.first() to it.last() }
             val pathCopyMap = pathMap.map { (expected, test) -> expected to createTestFile(test) }
-            val testCopyNames = pathCopyMap.joinToString { (_, testCopy) -> testCopy.toString() }
+            val testCopyNames = pathCopyMap.joinToString(separator = fixPluginConfig.separator!!) { (_, testCopy) -> testCopy.toString() }
 
             val execCmd = "${(generalConfig!!.execCmd)} ${fixPluginConfig.execFlags} $testCopyNames"
             val executionResult = try {

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -54,7 +54,7 @@ class FixPlugin(
         return files.chunked(fixPluginConfig.batchSize!!).map { chunk ->
             val pathMap = chunk.map { it.first() to it.last() }
             val pathCopyMap = pathMap.map { (expected, test) -> expected to createTestFile(test) }
-            val testCopyNames = pathCopyMap.joinToString(separator = fixPluginConfig.separator!!) { (_, testCopy) -> testCopy.toString() }
+            val testCopyNames = pathCopyMap.joinToString(separator = fixPluginConfig.batchSeparator!!) { (_, testCopy) -> testCopy.toString() }
 
             val execCmd = "${(generalConfig!!.execCmd)} ${fixPluginConfig.execFlags} $testCopyNames"
             val executionResult = try {

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPluginConfig.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPluginConfig.kt
@@ -22,13 +22,13 @@ import kotlinx.serialization.UseSerializers
  * @property batchSize it controls how many files execCmd will process at a time.
  * @property resourceNameTestSuffix suffix name of the test file.
  * @property resourceNameExpectedSuffix suffix name of the expected file.
- * @property separator
+ * @property batchSeparator
  */
 @Serializable
 data class FixPluginConfig(
     val execFlags: String? = null,
     val batchSize: Int? = null,
-    val separator: String? = null,
+    val batchSeparator: String? = null,
     val resourceNameTestSuffix: String? = null,
     val resourceNameExpectedSuffix: String? = null,
 ) : PluginConfig {
@@ -57,7 +57,7 @@ data class FixPluginConfig(
         return FixPluginConfig(
             this.execFlags ?: other.execFlags,
             this.batchSize ?: other.batchSize,
-            this.separator ?: other.separator,
+            this.batchSeparator ?: other.batchSeparator,
             this.resourceNameTestSuffix ?: other.resourceNameTestSuffix,
             this.resourceNameExpectedSuffix ?: other.resourceNameExpectedSuffix,
         )
@@ -66,7 +66,7 @@ data class FixPluginConfig(
     override fun validateAndSetDefaults() = FixPluginConfig(
         execFlags ?: "",
         batchSize ?: 1,
-        separator ?: ", ",
+        batchSeparator ?: ", ",
         resourceNameTest,
         resourceNameExpected
     )

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPluginConfig.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPluginConfig.kt
@@ -22,11 +22,13 @@ import kotlinx.serialization.UseSerializers
  * @property batchSize it controls how many files execCmd will process at a time.
  * @property resourceNameTestSuffix suffix name of the test file.
  * @property resourceNameExpectedSuffix suffix name of the expected file.
+ * @property separator
  */
 @Serializable
 data class FixPluginConfig(
     val execFlags: String? = null,
     val batchSize: Int? = null,
+    val separator: String? = null,
     val resourceNameTestSuffix: String? = null,
     val resourceNameExpectedSuffix: String? = null,
 ) : PluginConfig {
@@ -55,6 +57,7 @@ data class FixPluginConfig(
         return FixPluginConfig(
             this.execFlags ?: other.execFlags,
             this.batchSize ?: other.batchSize,
+            this.separator ?: other.separator,
             this.resourceNameTestSuffix ?: other.resourceNameTestSuffix,
             this.resourceNameExpectedSuffix ?: other.resourceNameExpectedSuffix,
         )
@@ -63,6 +66,7 @@ data class FixPluginConfig(
     override fun validateAndSetDefaults() = FixPluginConfig(
         execFlags ?: "",
         batchSize ?: 1,
+        separator ?: ", ",
         resourceNameTest,
         resourceNameExpected
     )

--- a/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
+++ b/save-plugins/fix-plugin/src/commonTest/kotlin/org/cqfn/save/plugins/fix/FixPluginTest.kt
@@ -135,15 +135,15 @@ class FixPluginTest {
             ProcessBuilder(false).exec("echo Expected file > $testFile2", null)
             "${diskWithTmpDir}cd $tmpDir && echo Expected file >"
         } else {
-            // We call ProcessBuilder ourselves, because the command ">" does not work for the list of files with separator ", "
-            ProcessBuilder(false).exec("echo Expected file > $testFile1", null)
             "${diskWithTmpDir}cd $tmpDir && echo Expected file | tee"
         }
+
+        val fixPluginConfig = if (isCurrentOsWindows()) FixPluginConfig(executionCmd, 2) else FixPluginConfig(executionCmd, 2, " ")
 
         val results = FixPlugin(TestConfig(config,
             null,
             mutableListOf(
-                FixPluginConfig(executionCmd, 2),
+                fixPluginConfig,
                 GeneralConfig("", "", "", "")
             )),
             testFiles = emptyList(),

--- a/save-plugins/warn-plugin/README.md
+++ b/save-plugins/warn-plugin/README.md
@@ -81,13 +81,13 @@ warningTextHasColumn = true # (default value)
 warningTextHasLine = true # (default value)
 testNameSuffix = "Test" # (default value)
 batchSize = 1 # (default value)
-separator = ", " # (default value)
+batchSeparator  = ", " # (default value)
 ```
 
 When executed from project root (where `save.propertes` is located), SAVE will cd to `rootDir` and discover all files
 matching `inputFilePattern`. It will then execute `$execCmd $testFile`. `batchSize` it controls how many files execCmd will process at a time. (since we specified
 `batchSize = 1`, it will provide inputs one by one) and compare warnings its stdout (as per `output` option) parsed using `warningsOutputPattern` with warnings
-parsed from the same `$testFile` using `warningsInputPattern`. . `separator` is a setting for batchSize.
+parsed from the same `$testFile` using `warningsInputPattern`. `batchSeparator` is separator for filenames in `execCmd` if `batchSize > 1`.
 
 `warningsInputPattern` and `warningsOutputPattern` must include some mandatory capture groups: for line number (if `warningTextHasLine` is true),
 for column number (if `warningTextHasColumn` is true) and for warning text. Their indices can be customized

--- a/save-plugins/warn-plugin/README.md
+++ b/save-plugins/warn-plugin/README.md
@@ -80,13 +80,14 @@ messageCaptureGroup = 4 # (default value)
 warningTextHasColumn = true # (default value)
 warningTextHasLine = true # (default value)
 testNameSuffix = "Test" # (default value)
-batchSize = 1
+batchSize = 1 # (default value)
+separator = ", " # (default value)
 ```
 
 When executed from project root (where `save.propertes` is located), SAVE will cd to `rootDir` and discover all files
 matching `inputFilePattern`. It will then execute `$execCmd $testFile`. `batchSize` it controls how many files execCmd will process at a time. (since we specified
 `batchSize = 1`, it will provide inputs one by one) and compare warnings its stdout (as per `output` option) parsed using `warningsOutputPattern` with warnings
-parsed from the same `$testFile` using `warningsInputPattern`.
+parsed from the same `$testFile` using `warningsInputPattern`. . `separator` is a setting for batchSize.
 
 `warningsInputPattern` and `warningsOutputPattern` must include some mandatory capture groups: for line number (if `warningTextHasLine` is true),
 for column number (if `warningTextHasColumn` is true) and for warning text. Their indices can be customized

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -101,7 +101,7 @@ class WarnPlugin(
             )
         }
 
-        val fileNames = paths.joinToString {
+        val fileNames = paths.joinToString(separator = warnPluginConfig.separator!!) {
             if (generalConfig!!.ignoreSaveComments == true) createTestFile(it, warnPluginConfig.warningsInputPattern!!) else it.toString()
         }
         val execCmd = "${generalConfig!!.execCmd} ${warnPluginConfig.execFlags} $fileNames"

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -101,7 +101,7 @@ class WarnPlugin(
             )
         }
 
-        val fileNames = paths.joinToString(separator = warnPluginConfig.separator!!) {
+        val fileNames = paths.joinToString(separator = warnPluginConfig.batchSeparator!!) {
             if (generalConfig!!.ignoreSaveComments == true) createTestFile(it, warnPluginConfig.warningsInputPattern!!) else it.toString()
         }
         val execCmd = "${generalConfig!!.execCmd} ${warnPluginConfig.execFlags} $fileNames"

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPluginConfig.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPluginConfig.kt
@@ -41,7 +41,7 @@ import kotlinx.serialization.UseSerializers
  * @property exactWarningsMatch exact match of errors
  * @property testNameSuffix suffix name of the test file.
  * @property batchSize it controls how many files execCmd will process at a time.
- * @property separator
+ * @property batchSeparator
  */
 @Serializable
 data class WarnPluginConfig(
@@ -51,7 +51,7 @@ data class WarnPluginConfig(
     val warningTextHasLine: Boolean? = null,
     val warningTextHasColumn: Boolean? = null,
     val batchSize: Int? = null,
-    val separator: String? = null,
+    val batchSeparator: String? = null,
     val lineCaptureGroup: Int? = null,
     val columnCaptureGroup: Int? = null,
     val messageCaptureGroup: Int? = null,
@@ -83,7 +83,7 @@ data class WarnPluginConfig(
             this.warningTextHasLine ?: other.warningTextHasLine,
             this.warningTextHasColumn ?: other.warningTextHasColumn,
             this.batchSize ?: other.batchSize,
-            this.separator ?: other.separator,
+            this.batchSeparator ?: other.batchSeparator,
             this.lineCaptureGroup ?: other.lineCaptureGroup,
             this.columnCaptureGroup ?: other.columnCaptureGroup,
             this.messageCaptureGroup ?: other.messageCaptureGroup,
@@ -104,7 +104,7 @@ data class WarnPluginConfig(
         val newWarningTextHasLine = warningTextHasLine ?: true
         val newWarningTextHasColumn = warningTextHasColumn ?: true
         val newBatchSize = batchSize ?: 1
-        val newSeparator = separator ?: ", "
+        val newBatchSeparator = batchSeparator ?: ", "
         val newLineCaptureGroup = if (newWarningTextHasLine) (lineCaptureGroup ?: 1) else null
         val newColumnCaptureGroup = if (newWarningTextHasColumn) (columnCaptureGroup ?: 2) else null
         val newMessageCaptureGroup = messageCaptureGroup ?: 3
@@ -122,7 +122,7 @@ data class WarnPluginConfig(
             newWarningTextHasLine,
             newWarningTextHasColumn,
             newBatchSize,
-            newSeparator,
+            newBatchSeparator,
             newLineCaptureGroup,
             newColumnCaptureGroup,
             newMessageCaptureGroup,

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPluginConfig.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPluginConfig.kt
@@ -41,6 +41,7 @@ import kotlinx.serialization.UseSerializers
  * @property exactWarningsMatch exact match of errors
  * @property testNameSuffix suffix name of the test file.
  * @property batchSize it controls how many files execCmd will process at a time.
+ * @property separator
  */
 @Serializable
 data class WarnPluginConfig(
@@ -50,6 +51,7 @@ data class WarnPluginConfig(
     val warningTextHasLine: Boolean? = null,
     val warningTextHasColumn: Boolean? = null,
     val batchSize: Int? = null,
+    val separator: String? = null,
     val lineCaptureGroup: Int? = null,
     val columnCaptureGroup: Int? = null,
     val messageCaptureGroup: Int? = null,
@@ -81,6 +83,7 @@ data class WarnPluginConfig(
             this.warningTextHasLine ?: other.warningTextHasLine,
             this.warningTextHasColumn ?: other.warningTextHasColumn,
             this.batchSize ?: other.batchSize,
+            this.separator ?: other.separator,
             this.lineCaptureGroup ?: other.lineCaptureGroup,
             this.columnCaptureGroup ?: other.columnCaptureGroup,
             this.messageCaptureGroup ?: other.messageCaptureGroup,
@@ -101,6 +104,7 @@ data class WarnPluginConfig(
         val newWarningTextHasLine = warningTextHasLine ?: true
         val newWarningTextHasColumn = warningTextHasColumn ?: true
         val newBatchSize = batchSize ?: 1
+        val newSeparator = separator ?: ", "
         val newLineCaptureGroup = if (newWarningTextHasLine) (lineCaptureGroup ?: 1) else null
         val newColumnCaptureGroup = if (newWarningTextHasColumn) (columnCaptureGroup ?: 2) else null
         val newMessageCaptureGroup = messageCaptureGroup ?: 3
@@ -118,6 +122,7 @@ data class WarnPluginConfig(
             newWarningTextHasLine,
             newWarningTextHasColumn,
             newBatchSize,
+            newSeparator,
             newLineCaptureGroup,
             newColumnCaptureGroup,
             newMessageCaptureGroup,

--- a/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/WarnPluginTest.kt
+++ b/save-plugins/warn-plugin/src/commonTest/kotlin/org/cqfn/save/plugin/warn/WarnPluginTest.kt
@@ -62,7 +62,7 @@ class WarnPluginTest {
                 "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("(.+):(\\d+):(\\d+): (.+)"),
-                true, true, 1, 1, 2, 3, 1, 2, 3, 4
+                true, true, 1, ", ", 1, 2, 3, 1, 2, 3, 4
             ),
             GeneralConfig("", "", "", "")
         ) { results ->
@@ -98,7 +98,7 @@ class WarnPluginTest {
                 "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("(.+):(\\d+):(\\d+): (.+)"),
-                true, true, 1, 1, 2, 3, 1, 2, 3, 4, false
+                true, true, 1, ", ", 1, 2, 3, 1, 2, 3, 4, false
             ),
             GeneralConfig("", "", "", "")
         ) { results ->
@@ -129,7 +129,7 @@ class WarnPluginTest {
                 "echo Test1Test.java:4:6: Class name should be in PascalCase",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("(.+):(\\d+):(\\d+): (.+)"),
-                true, true, 1, 1, 2, 3, 1, 2, 3, 4
+                true, true, 1, ", ", 1, 2, 3, 1, 2, 3, 4
             ),
             GeneralConfig("", "", "", "")
         ) { results ->
@@ -167,7 +167,7 @@ class WarnPluginTest {
                 "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("(.+):(\\d+):(\\d+): (.+)"),
-                true, true, 1, 1, 2, 3, 1, 2, 3, 4
+                true, true, 1, ", ", 1, 2, 3, 1, 2, 3, 4
             ),
             GeneralConfig("", "", "", "")
         ) { results ->
@@ -207,7 +207,7 @@ class WarnPluginTest {
                 "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("(.+):(\\d+):(\\d+): (.+)"),
-                true, true, 1, 1, 2, 3, 1, 2, 3, 4
+                true, true, 1, ", ", 1, 2, 3, 1, 2, 3, 4
             ),
             GeneralConfig("", "", "", "")
         ) { results ->
@@ -246,7 +246,7 @@ class WarnPluginTest {
                 "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn: (.*)"),
                 Regex("(.+): (.+)"),
-                false, false, 1, null, null, 1, 1, null, null, 2
+                false, false, 1, ", ", null, null, 1, 1, null, null, 2
             ), GeneralConfig("", "", "", "")
         ) { results ->
             assertEquals(1, results.size)
@@ -293,7 +293,7 @@ class WarnPluginTest {
                 "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("(.+):(\\d+):(\\d+): (.+)"),
-                true, true, batchSize, 1, 2, 3, 1, 2, 3, 4
+                true, true, batchSize, ", ", 1, 2, 3, 1, 2, 3, 4
             ),
             GeneralConfig("", "", "", "")
         ) { results ->
@@ -326,7 +326,7 @@ class WarnPluginTest {
                 "$catCmd ${tmpDir / "resource"} && set stub=",
                 Regex("// ;warn:(\\d+):(\\d+): (.*)"),
                 Regex("(.+):(\\d+):(\\d+): (.+)"),
-                true, true, batchSize, 1, 2, 3, 1, 2, 3, 4
+                true, true, batchSize, ", ", 1, 2, 3, 1, 2, 3, 4
             ),
             GeneralConfig("", "", "", "")
         ) { results ->


### PR DESCRIPTION
What's done:
* Added separator config for a FixPlugin and WarnPlugin
Closes #158