### PR TITLE
warn-plugin: Some warnings are at the end of the file

### DIFF
--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -79,8 +79,9 @@ class WarnPlugin(
             x++
         }
         val newLine = lineNum + x
-        if (newLine >= sizeFile) {
-            logWarn("Some warnings are at the end of the file. They will be assigned the following line: $newLine")
+        if (newLine > sizeFile) {
+            logWarn("Some warnings are at the end of the file. They will be assigned the following line: $sizeFile")
+            return sizeFile
         }
         return newLine
     }

--- a/save-plugins/warn-plugin/src/commonNonJsTest/kotlin/org/cqfn/save/plugin/warn/WarnPluginTest.kt
+++ b/save-plugins/warn-plugin/src/commonNonJsTest/kotlin/org/cqfn/save/plugin/warn/WarnPluginTest.kt
@@ -83,7 +83,7 @@ class WarnPluginTest {
                 |Test1Test.java:5: Class name should be in PascalCase
                 |Test1Test.java:5: Class name shouldn't have a number
                 |Test1Test.java:7: Variable name should be in LowerCase
-                |Test1Test.java:10: Class should have a Kdoc
+                |Test1Test.java:9: Class should have a Kdoc
                 """.trimMargin().encodeToByteArray()
             )
         }


### PR DESCRIPTION
What's done:
* Fixed bug in function plusLine
Closes #201