### PR TITLE
fix-plugin: Change directory to root test config location before running `execCmd`

### DIFF
--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -60,7 +60,7 @@ class FixPlugin(
 
             val execCmd = "${(generalConfig.execCmd)} ${fixPluginConfig.execFlags} $testCopyNames"
             val executionResult = try {
-                pb.exec(execCmd, redirectTo)
+                pb.exec("cd ${testConfig.getRootConfig().directory} && $execCmd", redirectTo)
             } catch (ex: ProcessExecutionException) {
                 return@map chunk.map {
                     TestResult(


### PR DESCRIPTION
Closes #222 