### PR TITLE
Trimming useless spaces in warning message

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -6,7 +6,6 @@ object Versions {
     const val okio = "3.0.0-alpha.8"
     const val ktoml = "0.2.7"
     const val multiplatformDiff = "0.2.0"
-    const val ktorVersion = "1.6.1"
 
     object Kotlinx {
         const val serialization = "1.2.2"

--- a/examples/kotlin-diktat/warn/save.toml
+++ b/examples/kotlin-diktat/warn/save.toml
@@ -8,7 +8,7 @@ suiteName = "warnings"
 testNameSuffix = "Test.kt"
 wildCardInDirectoryMode = "**/*"
 # diktat warnings have the following format: filename.kt:1:15: [WARN_NAME] my waring
-actualWarningsPattern="(\\w+\\..+):(\\d+):(\\d+): (\\[.*\\].*)$"
+actualWarningsPattern="(\\w+\\..+):(\\d+):(\\d+): (\\[.*\\].*)"
 lineCaptureGroup = 1
 columnCaptureGroup = 2
 messageCaptureGroup = 3

--- a/save-core/build.gradle.kts
+++ b/save-core/build.gradle.kts
@@ -32,19 +32,6 @@ kotlin {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
-                implementation("io.ktor:ktor-client-core:${Versions.ktorVersion}")
-            }
-        }
-
-        val jvmTest by getting {
-            dependencies {
-                implementation("io.ktor:ktor-client-apache:${Versions.ktorVersion}")
-            }
-        }
-
-        val nativeTest by getting {
-            dependencies {
-                implementation("io.ktor:ktor-client-curl:${Versions.ktorVersion}")
             }
         }
     }

--- a/save-core/src/commonNonJsTest/kotlin/org/cqfn/save/core/integration/ClassicWarnTest.kt
+++ b/save-core/src/commonNonJsTest/kotlin/org/cqfn/save/core/integration/ClassicWarnTest.kt
@@ -1,6 +1,5 @@
 package org.cqfn.save.core.integration
 
-import org.cqfn.save.core.test.utils.runTest
 import org.cqfn.save.core.test.utils.runTestsWithDiktat
 
 import kotlin.test.Ignore
@@ -20,56 +19,50 @@ import kotlin.test.Test
 class ClassicWarnTest {
     @Test
     @Ignore  // fixme: change directory in fix-plugin too?
-    fun `execute warn plugin with default testFiles`() = runTest {
-        runTestsWithDiktat(
-            null, 9
-        )
-    }
+    fun `execute warn plugin with default testFiles`() =
+            runTestsWithDiktat(
+                null, 9
+            )
 
     @Test
-    fun `execute warn plugin on separate files`() = runTest {
-        runTestsWithDiktat(
-            listOf(
-                "warn/chapter1/EnumValueSnakeCaseTest.kt",
-                "warn/chapter1/GenericFunctionTest.kt"
-            ), 2
-        )
-    }
+    fun `execute warn plugin on separate files`() =
+            runTestsWithDiktat(
+                listOf(
+                    "warn/chapter1/EnumValueSnakeCaseTest.kt",
+                    "warn/chapter1/GenericFunctionTest.kt"
+                ), 2
+            )
 
     @Test
-    fun `executing warn plugin on directory`() = runTest {
-        runTestsWithDiktat(
-            listOf(
-                "warn/chapter1"
-            ), 2
-        )
-    }
+    fun `executing warn plugin on directory`() =
+            runTestsWithDiktat(
+                listOf(
+                    "warn/chapter1"
+                ), 2
+            )
 
     @Test
-    fun `executing warn plugin on save-toml file in directory`() = runTest {
-        runTestsWithDiktat(
-            listOf(
-                "warn/save.toml"
-            ), 2
-        )
-    }
+    fun `executing warn plugin on save-toml file in directory`() =
+            runTestsWithDiktat(
+                listOf(
+                    "warn/save.toml"
+                ), 2
+            )
 
     @Test
-    fun `executing warn plugin on parental save-toml file`() = runTest {
-        runTestsWithDiktat(
-            listOf(
-                "warn/chapter1/save.toml"
-            ), 2
-        )
-    }
+    fun `executing warn plugin on parental save-toml file`() =
+            runTestsWithDiktat(
+                listOf(
+                    "warn/chapter1/save.toml"
+                ), 2
+            )
 
     @Test
-    fun `execute warn plugin with included and excluded suites`() = runTest {
-        runTestsWithDiktat(
-            emptyList(), 2
-        ) {
-            includeSuites = "warnings,DocsCheck"
-            excludeSuites = "Chapter1,Chapter2,Chapter3"
-        }
-    }
+    fun `execute warn plugin with included and excluded suites`() =
+            runTestsWithDiktat(
+                emptyList(), 2
+            ) {
+                includeSuites = "warnings,DocsCheck"
+                excludeSuites = "Chapter1,Chapter2,Chapter3"
+            }
 }

--- a/save-core/src/commonNonJsTest/kotlin/org/cqfn/save/core/integration/WarnDirTest.kt
+++ b/save-core/src/commonNonJsTest/kotlin/org/cqfn/save/core/integration/WarnDirTest.kt
@@ -1,6 +1,5 @@
 package org.cqfn.save.core.integration
 
-import org.cqfn.save.core.test.utils.runTest
 import org.cqfn.save.core.test.utils.runTestsWithDiktat
 
 import kotlin.test.Test
@@ -11,17 +10,14 @@ import kotlin.test.Test
 
 class WarnDirTest {
     @Test
-    fun `execute warn plugin on the directory chapter1`() = runTest {
-        runTestsWithDiktat(listOf("warn-dir/chapter1"), 3)
-    }
+    fun `execute warn plugin on the directory chapter1`() =
+            runTestsWithDiktat(listOf("warn-dir/chapter1"), 3)
 
     @Test
-    fun `execute warn plugin on the directory chapter2`() = runTest {
-        runTestsWithDiktat(listOf("warn-dir/chapter2"), 1)
-    }
+    fun `execute warn plugin on the directory chapter2`() =
+            runTestsWithDiktat(listOf("warn-dir/chapter2"), 1)
 
     @Test
-    fun `execute warn plugin on the directory chapter3`() = runTest {
-        runTestsWithDiktat(listOf("warn-dir/chapter3"), 1)
-    }
+    fun `execute warn plugin on the directory chapter3`() =
+            runTestsWithDiktat(listOf("warn-dir/chapter3"), 1)
 }

--- a/save-core/src/commonNonJsTest/kotlin/org/cqfn/save/core/test/utils/TestUtilsCommon.kt
+++ b/save-core/src/commonNonJsTest/kotlin/org/cqfn/save/core/test/utils/TestUtilsCommon.kt
@@ -10,88 +10,22 @@ import org.cqfn.save.core.Save
 import org.cqfn.save.core.config.OutputStreamType
 import org.cqfn.save.core.config.ReportType
 import org.cqfn.save.core.config.SaveProperties
-import org.cqfn.save.core.files.createFile
-import org.cqfn.save.core.logging.logDebug
 import org.cqfn.save.core.result.Pass
 import org.cqfn.save.reporter.test.TestReporter
 
-import io.ktor.client.*
-import io.ktor.client.call.receive
-import io.ktor.client.features.HttpTimeout
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
 import okio.FileSystem
-import okio.Path.Companion.toPath
 
 import kotlin.test.assertEquals
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.runBlocking
-
-const val KTLINT_VERSION = "0.39.0"
-const val DIKTAT_VERSION = "1.0.0-rc.2"
-const val TIMEOUT = 100_000L
-
-/**
- * Workaround to use suspending functions in unit tests
- *
- * @param block
- * @return the result of blocked suspend function
- */
-fun runTest(block: suspend (scope: CoroutineScope) -> Unit) = runBlocking { block(this) }
-
-/**
- * Download file from [url] into [fileName]
- *
- * @param url url to download from
- * @param fileName name of the downloaded file
- * @return path to the downloaded file as a string
- */
-suspend fun downloadFile(url: String, fileName: String): String {
-    val fs = FileSystem.SYSTEM
-    val client = HttpClient {
-        install(HttpTimeout) {
-            requestTimeoutMillis = TIMEOUT
-            connectTimeoutMillis = TIMEOUT
-            socketTimeoutMillis = TIMEOUT
-        }
-    }
-
-    val file = fileName.toPath()
-    if (!fs.exists(file)) {
-        val httpResponse: HttpResponse = client.get(url)
-        val responseBody: ByteArray = httpResponse.receive()
-        logDebug("Writing ${responseBody.size} bytes into $file")
-        val newPath = fs.createFile(fileName)
-        fs.write(newPath) {
-            write(responseBody)
-        }
-        logDebug("$url downloaded to $file")
-    }
-
-    client.close()
-    return file.toString()
-}
 
 /**
  * @param testDir `testFiles` as accepted by save-cli
  * @param numberOfTests expected number of executed tests with this configuration
  * @param addProperties lambda to add/override SaveProperties during test
  */
-suspend fun runTestsWithDiktat(
+fun runTestsWithDiktat(
     testDir: List<String>?,
     numberOfTests: Int,
     addProperties: SaveProperties.() -> Unit = {}) {
-    downloadFile(
-        "https://github.com/pinterest/ktlint/releases/download/$KTLINT_VERSION/ktlint",
-        "../examples/kotlin-diktat/ktlint"
-    )
-
-    downloadFile(
-        "https://github.com/cqfn/diKTat/releases/download/v$DIKTAT_VERSION/diktat-$DIKTAT_VERSION.jar",
-        "../examples/kotlin-diktat/diktat.jar"
-    )
-
     val saveProperties = SaveProperties(
         testFiles = testDir,
         testRootPath = "../examples/kotlin-diktat/",

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/utils/Warning.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/utils/Warning.kt
@@ -45,7 +45,7 @@ internal fun String.extractWarning(warningRegex: Regex,
     val groups = warningRegex.find(this)?.groups ?: return null
 
     val column = getRegexGroupSafe(columnGroupIdx, groups, this, "column number")?.toIntOrNull()
-    val message = getRegexGroupSafe(messageGroupIdx, groups, this, "warning message")!!
+    val message = getRegexGroupSafe(messageGroupIdx, groups, this, "warning message")!!.trim()
     return Warning(
         message,
         line,

--- a/save-plugins/warn-plugin/src/commonNonJsTest/kotlin/org/cqfn/save/plugin/warn/utils/UtilsTest.kt
+++ b/save-plugins/warn-plugin/src/commonNonJsTest/kotlin/org/cqfn/save/plugin/warn/utils/UtilsTest.kt
@@ -24,7 +24,7 @@ class UtilsTest {
         assertExtracts(
             config,
             "// ;warn:1:2:  Foo bar baz",
-            Warning(" Foo bar baz", 1, 2, "Test.kt"),
+            Warning("Foo bar baz", 1, 2, "Test.kt"),
             defaultInputPattern
         )
         assertExtractionFails(config, "// warn:1:2 Foo bar baz", defaultInputPattern)
@@ -49,7 +49,7 @@ class UtilsTest {
         assertExtracts(
             config,
             ";warn:2:  Foo bar baz",
-            Warning(" Foo bar baz", null, 2, "Test.kt"),
+            Warning("Foo bar baz", null, 2, "Test.kt"),
             Regex(";warn:(\\d+): (.+)")
         )
         assertExtractionFails(config, "warn:1:2 Foo bar baz", Regex(";warn:(\\d+): (.+)"))
@@ -74,7 +74,7 @@ class UtilsTest {
         assertExtracts(
             config,
             ";warn:2:  Foo bar baz",
-            Warning(" Foo bar baz", 2, null, "Test.kt"),
+            Warning("Foo bar baz", 2, null, "Test.kt"),
             Regex(";warn:(\\d+): (.+)")
         )
         assertExtractionFails(config, "warn:1:2 Foo bar baz", Regex(";warn:(\\d+): (.+)"))


### PR DESCRIPTION
### What's done:
- spaces will be trimmed in the warning message
- removed downloading of binaries from tests