### PR TITLE
Get rid of makeThePathRelativeToTestRoot function

### DIFF
--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/files/FileUtils.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/files/FileUtils.kt
@@ -217,7 +217,7 @@ private fun createRelativePathFromThisToTheRoot(currentPath: Path, rootPath: Pat
 
     // Files located at the same directory, no need additional operations
     if (rootDirectory == parentDirectory) {
-        return ""
+        return currentPath.name
     }
     // Goes through all intermediate dirs and construct relative path
     var relativePath = ""
@@ -225,5 +225,5 @@ private fun createRelativePathFromThisToTheRoot(currentPath: Path, rootPath: Pat
         relativePath = parentDirectory.name + Path.DIRECTORY_SEPARATOR + relativePath
         parentDirectory = parentDirectory.parent!!
     }
-    return relativePath
+    return relativePath + currentPath.name
 }

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
@@ -10,7 +10,6 @@ import org.cqfn.save.core.utils.ProcessBuilder
 
 import okio.FileSystem
 import okio.Path
-import okio.Path.Companion.toPath
 
 /**
  * Plugin that can be injected into SAVE during execution. Plugins accept contents of configuration file and then perform some work.
@@ -99,8 +98,7 @@ abstract class Plugin(
         // creating relative to root path from a test file
         // "Expected" file for Fix plugin
         val testFileRelative =
-                (testFiles.test.createRelativePathToTheRoot(testRepositoryRoot).toPath() / testFiles.test.name)
-                    .toString()
+                (testFiles.test.createRelativePathToTheRoot(testRepositoryRoot))
                     .replace('\\', '/')
 
         // excluding tests that are included in the excluded list
@@ -170,7 +168,7 @@ abstract class Plugin(
     protected fun constructPathForCopyOfTestFile(dirName: String, path: Path): Path {
         val tmpDir = (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / dirName)
         val relativePath = path.createRelativePathToTheRoot(testConfig.getRootConfig().location)
-        return tmpDir / relativePath / path.name
+        return tmpDir / relativePath
     }
 
     /**

--- a/save-common/src/commonNonJsTest/kotlin/org/cqfn/save/core/files/FileUtilsTest.kt
+++ b/save-common/src/commonNonJsTest/kotlin/org/cqfn/save/core/files/FileUtilsTest.kt
@@ -95,8 +95,8 @@ class FileUtilsTest {
         val config = fs.createFile(tmpDir / "save.toml")
         val testFile = fs.createFile(tmpDir / "Test1Test.java")
 
-        // Should be nothing, since they located in the same dir
-        assertEquals("", testFile.createRelativePathToTheRoot(config))
+        // Should be name of current file, since they are located in the same dir
+        assertEquals("Test1Test.java", testFile.createRelativePathToTheRoot(config))
     }
 
     @Test
@@ -117,15 +117,15 @@ class FileUtilsTest {
 
         val separator = Path.DIRECTORY_SEPARATOR
 
-        assertEquals("", testFile1.createRelativePathToTheRoot(config1))
-        assertEquals("dir2$separator", testFile2.createRelativePathToTheRoot(config1))
-        assertEquals("dir2${separator}dir3$separator", testFile3.createRelativePathToTheRoot(config1))
-        assertEquals("dir2${separator}dir3${separator}dir33$separator", testFile33.createRelativePathToTheRoot(config1))
+        assertEquals("Test1Test.java", testFile1.createRelativePathToTheRoot(config1))
+        assertEquals("dir2${separator}Test2Test.java", testFile2.createRelativePathToTheRoot(config1))
+        assertEquals("dir2${separator}dir3${separator}Test3Test.java", testFile3.createRelativePathToTheRoot(config1))
+        assertEquals("dir2${separator}dir3${separator}dir33${separator}Test33Test.java", testFile33.createRelativePathToTheRoot(config1))
 
-        assertEquals("dir33$separator", testFile33.createRelativePathToTheRoot(config3))
-        assertEquals("dir3${separator}dir33$separator", testFile33.createRelativePathToTheRoot(config2))
+        assertEquals("dir33${separator}Test33Test.java", testFile33.createRelativePathToTheRoot(config3))
+        assertEquals("dir3${separator}dir33${separator}Test33Test.java", testFile33.createRelativePathToTheRoot(config2))
         val dir4 = tmpDir / "dir2" / "dir3" / "dir4"
-        assertEquals("dir2${separator}dir3$separator", dir4.createRelativePathToTheRoot(config1))
-        assertEquals("dir2${separator}dir3$separator", dir4.createRelativePathToTheRoot(tmpDir))
+        assertEquals("dir2${separator}dir3${separator}dir4", dir4.createRelativePathToTheRoot(config1))
+        assertEquals("dir2${separator}dir3${separator}dir4", dir4.createRelativePathToTheRoot(tmpDir))
     }
 }

--- a/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/Save.kt
+++ b/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/Save.kt
@@ -127,7 +127,7 @@ class Save(
                 .onEach { event ->
                     // calculate relative paths, because reporters don't need paths higher than root dir
                     val resourcesRelative =
-                            event.resources.map { it.createRelativePathToTheRoot(testRepositoryRootPath).toPath() }/// it.name }
+                            event.resources.map { it.createRelativePathToTheRoot(testRepositoryRootPath).toPath() }
                     reporter.onEvent(event.copy(resources = resourcesRelative))
                 }
                 .forEach(this::handleResult)

--- a/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/Save.kt
+++ b/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/Save.kt
@@ -127,7 +127,7 @@ class Save(
                 .onEach { event ->
                     // calculate relative paths, because reporters don't need paths higher than root dir
                     val resourcesRelative =
-                            event.resources.map { it.createRelativePathToTheRoot(testRepositoryRootPath).toPath() / it.name }
+                            event.resources.map { it.createRelativePathToTheRoot(testRepositoryRootPath).toPath() }/// it.name }
                     reporter.onEvent(event.copy(resources = resourcesRelative))
                 }
                 .forEach(this::handleResult)

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -1,6 +1,7 @@
 package org.cqfn.save.plugin.warn
 
 import org.cqfn.save.core.config.TestConfig
+import org.cqfn.save.core.files.createRelativePathToTheRoot
 import org.cqfn.save.core.files.readLines
 import org.cqfn.save.core.logging.describe
 import org.cqfn.save.core.logging.logWarn
@@ -20,7 +21,6 @@ import org.cqfn.save.plugin.warn.utils.resolvePlaceholdersFrom
 
 import okio.FileSystem
 import okio.Path
-import org.cqfn.save.core.files.createRelativePathToTheRoot
 
 private typealias WarningMap = Map<String, List<Warning>>
 
@@ -122,13 +122,11 @@ class WarnPlugin(
                     val directoryPrefix = testConfig
                         .directory
                         .createRelativePathToTheRoot(testConfig.getRootConfig().location)
-                        //.toString()
-                        //.makeThePathRelativeToTestRoot()
                     // a hack to put only the directory path to the execution command
                     // only in case a directory mode is enabled
                     "$directoryPrefix$it${warnPluginConfig.testNameSuffix}"
                 } ?: paths.joinToString(separator = warnPluginConfig.batchSeparator!!) {
-                    it.createRelativePathToTheRoot(testConfig.getRootConfig().location)//.makeThePathRelativeToTestRoot()
+                    it.createRelativePathToTheRoot(testConfig.getRootConfig().location)
                 }
 
         val execFlagsAdjusted = warnPluginConfig.resolvePlaceholdersFrom(extraFlags, fileNamesForExecCmd)
@@ -178,15 +176,6 @@ class WarnPlugin(
                 )
             )
         }.asSequence()
-    }
-
-    private fun String.makeThePathRelativeToTestRoot(): String {
-        val testRoot = testConfig.getRootConfig().directory.toString()
-        if (testRoot == ".") {
-            return this
-        }
-        return this.replace(testRoot, "")
-            .trimStart('/', '\\')
     }
 
     /**

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -20,6 +20,7 @@ import org.cqfn.save.plugin.warn.utils.resolvePlaceholdersFrom
 
 import okio.FileSystem
 import okio.Path
+import org.cqfn.save.core.files.createRelativePathToTheRoot
 
 private typealias WarningMap = Map<String, List<Warning>>
 
@@ -120,13 +121,14 @@ class WarnPlugin(
                 warnPluginConfig.wildCardInDirectoryMode?.let {
                     val directoryPrefix = testConfig
                         .directory
-                        .toString()
-                        .makeThePathRelativeToTestRoot()
+                        .createRelativePathToTheRoot(testConfig.getRootConfig().location)
+                        //.toString()
+                        //.makeThePathRelativeToTestRoot()
                     // a hack to put only the directory path to the execution command
                     // only in case a directory mode is enabled
                     "$directoryPrefix$it${warnPluginConfig.testNameSuffix}"
                 } ?: paths.joinToString(separator = warnPluginConfig.batchSeparator!!) {
-                    it.toString().makeThePathRelativeToTestRoot()
+                    it.createRelativePathToTheRoot(testConfig.getRootConfig().location)//.makeThePathRelativeToTestRoot()
                 }
 
         val execFlagsAdjusted = warnPluginConfig.resolvePlaceholdersFrom(extraFlags, fileNamesForExecCmd)


### PR DESCRIPTION
### What's done:
* Remove `makeThePathRelativeToTestRoot` as duplicate
* Change API in `createRelativePathToTheRoot` - now it also return the name of current file, since it is more proper for `relative path`
* Update tests