### PR TITLE
CLI: if user misprinted with the cli-argument - save should make a normal logging instead of 'directory not found'

### DIFF
--- a/save-cli/src/nativeMain/kotlin/org/cqfn/save/cli/SaveConfigReader.kt
+++ b/save-cli/src/nativeMain/kotlin/org/cqfn/save/cli/SaveConfigReader.kt
@@ -29,8 +29,8 @@ fun SaveProperties.validate(): SaveProperties {
     if (this.testFiles.isNullOrEmpty()) {
         logErrorAndExit(
             ExitCodes.INVALID_CONFIGURATION,
-            "test files list in CLI is missing or null. " +
-                    "Save is not able to start processing without an information about the tests or test root path that should be run."
+            "List with test files passed in CLI to save is missing or null. " +
+                    "Save is not able to start processing without an information about the tests or test root path that should be used for execution."
         )
     }
     // FixMe: get(0) to [0] after https://github.com/cqfn/diKTat/issues/1047
@@ -146,5 +146,5 @@ private fun errorAndExitNotValidDir(testRootPath: Path) {
         ExitCodes.INVALID_CONFIGURATION,
         "Save parsed the argument '$testRootPath' that you have provided to cli as a root for test directory and is not able to find it. " +
                 "Please provide a valid path to the root directory of test files. " +
-                "If you wanted to pass a configuration option instead, please check the list of available options using '—help'.")
+                "If you wanted to pass a configuration option instead, please check the list of available options using '--help'.")
 }

--- a/save-cli/src/nativeMain/kotlin/org/cqfn/save/cli/SaveConfigReader.kt
+++ b/save-cli/src/nativeMain/kotlin/org/cqfn/save/cli/SaveConfigReader.kt
@@ -26,9 +26,13 @@ private val fs: FileSystem = FileSystem.SYSTEM
  * @return this config in case we have valid configuration
  */
 fun SaveProperties.validate(): SaveProperties {
-    this.testFiles ?: logErrorAndExit(ExitCodes.INVALID_CONFIGURATION,
-        "`test files list in CLI is missing or null. " +
-                "Save is not able to start processing without an information about the tests that should be run.")
+    if (this.testFiles.isNullOrEmpty()) {
+        logErrorAndExit(
+            ExitCodes.INVALID_CONFIGURATION,
+            "test files list in CLI is missing or null. " +
+                    "Save is not able to start processing without an information about the tests or test root path that should be run."
+        )
+    }
     // FixMe: get(0) to [0] after https://github.com/cqfn/diKTat/issues/1047
     val testRootPath = testFiles!!.get(0).toPath()
     try {
@@ -139,6 +143,8 @@ private fun errorAndExitNotFoundDir() {
 
 private fun errorAndExitNotValidDir(testRootPath: Path) {
     logErrorAndExit(
-        ExitCodes.INVALID_CONFIGURATION, "Not able to find directory '$testRootPath'." +
-                " Please provide a valid path to the root directory of test files.")
+        ExitCodes.INVALID_CONFIGURATION,
+        "Save parsed the argument '$testRootPath' that you have provided to cli as a root for test directory and is not able to find it. " +
+                "Please provide a valid path to the root directory of test files. " +
+                "If you wanted to pass a configuration option instead, please check the list of available options using '—help'.")
 }

--- a/save-cli/src/nativeMain/kotlin/org/cqfn/save/cli/SaveConfigReader.kt
+++ b/save-cli/src/nativeMain/kotlin/org/cqfn/save/cli/SaveConfigReader.kt
@@ -137,7 +137,7 @@ private fun tryToUpdateDebugLevel(properties: SaveProperties) {
 
 private fun errorAndExitNotFoundDir() {
     logErrorAndExit(ExitCodes.INVALID_CONFIGURATION,
-        "Save expects to get the root directory for test files as the last CLI argument. " +
+        "Save expects to get the root directory for test files as the last CLI argument: save [cli-options] <test-root> [particular tests (optional)]" +
                 "Save is not able to start processing without an information about the tests that should be run.")
 }
 

--- a/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/Save.kt
+++ b/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/Save.kt
@@ -55,7 +55,7 @@ class Save(
         val testRootPath = saveProperties.testFiles!!.get(0).toPath()
         val rootTestConfigPath = testRootPath / "save.toml"
         val (requestedConfigs, requestedTests) = saveProperties.testFiles!!
-            .drop(0)
+            .drop(1)
             .map { testRootPath / it }
             .map { it.toString() }
             .partition { it.toPath().isSaveTomlConfig() }

--- a/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/Save.kt
+++ b/save-core/src/commonNonJsMain/kotlin/org/cqfn/save/core/Save.kt
@@ -95,11 +95,14 @@ class Save(
         val saveToml = testConfigs.map { it.getGeneralConfig()?.configLocation }
         val excluded = testConfigs.map { it.getGeneralConfig()?.excludedTests?.toMutableList() ?: emptyList() }
             .reduceOrNull { acc, list -> acc + list }
+        val excludedNote = excluded?.let {
+            "Note: please check excludedTests: $excluded in following save.toml files: $saveToml"
+        } ?: ""
         if (!atLeastOneExecutionProvided) {
             val warnMsg = if (requestedTests.isNotEmpty()) {
                 """|Couldn't find any satisfied test resources for `$requestedTests`
                    |Please check the correctness of command and consider, that the last arguments treats as test file names for individual execution.
-                   |Note: please check excludedTests: $excluded in following save.toml files: $saveToml
+                   |$excludedNote
                 """.trimMargin()
             } else {
                 "SAVE wasn't able to run tests, please check the correctness of configuration and test resources"


### PR DESCRIPTION
What's done:
* Fixed IndexOutOfBoundsException
Closes #253