### PR TITLE
Calculate number of tests in PlainTextReporter

### DIFF
--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/reporter/Statistics.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/reporter/Statistics.kt
@@ -42,12 +42,12 @@ class Statistics {
      */
     @Suppress("WHEN_WITHOUT_ELSE")
     fun updateFrom(event: TestResult) {
-        total.inc()
+        total += 1
         when (event.status) {
-            is Pass -> passed.inc()
-            is Fail -> failed.inc()
-            is Ignored -> skipped.inc()
-            is Crash -> crashed.inc()
+            is Pass -> passed += 1
+            is Fail -> failed += 1
+            is Ignored -> skipped += 1
+            is Crash -> crashed += 1
         }
     }
 }

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/reporter/Statistics.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/reporter/Statistics.kt
@@ -1,0 +1,53 @@
+package org.cqfn.save.core.reporter
+
+import org.cqfn.save.core.result.Crash
+import org.cqfn.save.core.result.Fail
+import org.cqfn.save.core.result.Ignored
+import org.cqfn.save.core.result.Pass
+import org.cqfn.save.core.result.TestResult
+
+/**
+ * Container for statistics about executed tests
+ */
+class Statistics {
+    /**
+     * Total number of tests
+     */
+    var total: Int = 0
+
+    /**
+     * Number of passed tests
+     */
+    var passed: Int = 0
+
+    /**
+     * Number of failed tests
+     */
+    var failed: Int = 0
+
+    /**
+     * Number of skipped tests
+     */
+    var skipped: Int = 0
+
+    /**
+     * Number of tests which have crashed
+     */
+    var crashed: Int = 0
+
+    /**
+     * Update fields of this class based on the received [TestResult]
+     *
+     * @param event an event to update statistics
+     */
+    @Suppress("WHEN_WITHOUT_ELSE")
+    fun updateFrom(event: TestResult) {
+        total.inc()
+        when (event.status) {
+            is Pass -> passed.inc()
+            is Fail -> failed.inc()
+            is Ignored -> skipped.inc()
+            is Crash -> crashed.inc()
+        }
+    }
+}

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/reporter/Statistics.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/reporter/Statistics.kt
@@ -42,12 +42,12 @@ class Statistics {
      */
     @Suppress("WHEN_WITHOUT_ELSE")
     fun updateFrom(event: TestResult) {
-        total += 1
+        total++
         when (event.status) {
-            is Pass -> passed += 1
-            is Fail -> failed += 1
-            is Ignored -> skipped += 1
-            is Crash -> crashed += 1
+            is Pass -> passed++
+            is Fail -> failed++
+            is Ignored -> skipped++
+            is Crash -> crashed++
         }
     }
 }

--- a/save-reporters/src/commonMain/kotlin/org/cqfn/save/reporter/plain/PlainTextReporter.kt
+++ b/save-reporters/src/commonMain/kotlin/org/cqfn/save/reporter/plain/PlainTextReporter.kt
@@ -34,14 +34,15 @@ class PlainTextReporter(override val out: BufferedSink) : Reporter {
         out.write(headers.joinToString(prefix = "| ", separator = " | ", postfix = " |\n") { "------" }.encodeToByteArray())
     }
 
+    @Suppress("MAGIC_NUMBER", "MagicNumber")
     override fun afterAll() {
         out.write("--------------------------------\n".encodeToByteArray())
         with(statistics) {
-            val passRate = passed / total * 100
+            val passRate = if (total > 0) passed / total * 100 else 0
             val status = if (passed == total) "SUCCESS" else "FAILED"
             // `%` should be escaped as `%%` for correct printing
             out.write(
-                "$status: $total tests, ${passRate}%% successful, failed: $failed, skipped: $skipped"
+                "$status: $total tests, $passRate%% successful, failed: $failed, skipped: $skipped"
                     .encodeToByteArray()
             )
         }

--- a/save-reporters/src/commonMain/kotlin/org/cqfn/save/reporter/plain/PlainTextReporter.kt
+++ b/save-reporters/src/commonMain/kotlin/org/cqfn/save/reporter/plain/PlainTextReporter.kt
@@ -24,7 +24,7 @@ class PlainTextReporter(override val out: BufferedSink) : Reporter {
     override val type: ReportType = ReportType.PLAIN
     private var currentTestSuite: String? = null
     private var currentPlugin: String? = null
-    private var statistics = Statistics()
+    private val statistics = Statistics()
 
     override fun beforeAll() {
         logDebug("Initializing reporter ${this::class.qualifiedName} of type $type\n")
@@ -37,8 +37,11 @@ class PlainTextReporter(override val out: BufferedSink) : Reporter {
     override fun afterAll() {
         out.write("--------------------------------\n".encodeToByteArray())
         with(statistics) {
+            val passRate = passed / total * 100
+            val status = if (passed == total) "SUCCESS" else "FAILED"
+            // `%` should be escaped as `%%` for correct printing
             out.write(
-                "Tests run: $total (passed: $passed, failed: $failed, skipped: $skipped)"
+                "$status: $total tests, ${passRate}%% successful, failed: $failed, skipped: $skipped"
                     .encodeToByteArray()
             )
         }


### PR DESCRIPTION
### What's done:
* Added Statistics.kt
* Use it in PlainTextReporter.kt

Closes #251

Now last lines of SAVE's output look like this:
```
| Chapter3 | WarnPlugin | warn-dir\chapter3\GenericFunctionTest.kt | Pass |  |
--------------------------------
SUCCESS: 9 tests, 100% successful, failed: 0, skipped: 0
[INFO]: SAVE has finished execution. You can rerun with --debug for additional information.
```