### PR TITLE
Bugfix: Restore movement of validation method

### DIFF
--- a/OptionsTable.md
+++ b/OptionsTable.md
@@ -7,7 +7,7 @@ Most (except for `-h` and `-prop`) of the options below can be passed to a SAVE 
 | t | threads | Number of threads | 1 |
 | d | debug | Turn on debug logging | false |
 | q | quiet | Do not log anything | false |
-| - | report-type | Type of generated report with execution results | JSON |
+| - | report-type | Type of generated report with execution results | PLAIN |
 | b | baseline | Path to the file with baseline data | - |
 | e | exclude-suites | Test suites, which won't be checked | - |
 | i | include-suites | Test suites, only which ones will be checked | - |

--- a/buildSrc/src/main/resources/config-options.json
+++ b/buildSrc/src/main/resources/config-options.json
@@ -37,7 +37,7 @@
       "fullName" : "report-type",
       "shortName" : "",
       "description" : "Type of generated report with execution results",
-      "default" : "ReportType.JSON"
+      "default" : "ReportType.PLAIN"
     },
     "baseline" : {
       "argType" : "ArgType.String",

--- a/examples/kotlin-diktat/fix/save.toml
+++ b/examples/kotlin-diktat/fix/save.toml
@@ -1,7 +1,6 @@
 [general]
     tags = ["fix"]
     description = "Test autofixing of issues discovered by diKTat"
-    suiteName = "autofix"
 
 [fix]
     execFlags = "-F"

--- a/examples/kotlin-diktat/warn-dir/save.toml
+++ b/examples/kotlin-diktat/warn-dir/save.toml
@@ -1,7 +1,6 @@
 [general]
 tags = ["warn"]
 description = "Test for directory mode"
-suiteName = "warnings"
 execCmd = "java -jar ktlint -R diktat.jar"
 expectedWarningsPattern = "// ;warn:(.+):(\\d+): (.+)"
 

--- a/examples/kotlin-diktat/warn-dir/save.toml
+++ b/examples/kotlin-diktat/warn-dir/save.toml
@@ -1,6 +1,7 @@
 [general]
 tags = ["warn"]
 description = "Test for directory mode"
+suiteName = "warnings"
 execCmd = "java -jar ktlint -R diktat.jar"
 expectedWarningsPattern = "// ;warn:(.+):(\\d+): (.+)"
 

--- a/examples/kotlin-diktat/warn-dir/save.toml
+++ b/examples/kotlin-diktat/warn-dir/save.toml
@@ -1,7 +1,6 @@
 [general]
     tags = ["warn"]
     description = "Test for directory mode"
-    suiteName = "Null Pointer"
 
 [warn]
     # suffix to detect tests

--- a/examples/kotlin-diktat/warn/save.toml
+++ b/examples/kotlin-diktat/warn/save.toml
@@ -1,7 +1,6 @@
 [general]
     tags = ["warn"]
     description = "Test warnings discovered by diKTat"
-    suiteName = "Autofix and Warn"
 
 [warn]
     # suffix to detect tests

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/Plugin.kt
@@ -31,9 +31,6 @@ abstract class Plugin(
      * Instance that is capable of executing processes
      */
     val pb = ProcessBuilder(useInternalRedirections, fs)
-    init {
-        testConfig.validateAndSetDefaults()
-    }
 
     /**
      * Perform plugin's work.

--- a/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/PluginConfig.kt
+++ b/save-common/src/commonMain/kotlin/org/cqfn/save/core/plugin/PluginConfig.kt
@@ -89,7 +89,7 @@ data class GeneralConfig(
             this.excludedTests ?: other.excludedTests,
             this.expectedWarningsPattern ?: other.expectedWarningsPattern,
             this.runConfigPattern ?: other.runConfigPattern,
-        )
+        ).also { it.configLocation = this.configLocation }
     }
 
     override fun validateAndSetDefaults(): GeneralConfig {
@@ -113,7 +113,7 @@ data class GeneralConfig(
             excludedTests ?: emptyList(),
             expectedWarningsPattern ?: defaultExpectedWarningPattern,
             runConfigPattern ?: defaultRunConfigPattern,
-        )
+        ).also { it.configLocation = this.configLocation }
     }
 
     private fun errorMsgForRequireCheck(field: String) =

--- a/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fixandwarn/FixAndWarnPlugin.kt
+++ b/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fixandwarn/FixAndWarnPlugin.kt
@@ -65,6 +65,7 @@ class FixAndWarnPlugin(
     )
 
     override fun handleFiles(files: Sequence<TestFiles>): Sequence<TestResult> {
+        testConfig.validateAndSetDefaults()
         // Need to update private fields after validation
         initOrUpdateConfigs()
         val expectedFiles = files.map { it as FixPlugin.FixTestFiles }.map { it.expected }

--- a/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fixandwarn/FixAndWarnPluginConfig.kt
+++ b/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fixandwarn/FixAndWarnPluginConfig.kt
@@ -32,7 +32,7 @@ data class FixAndWarnPluginConfig(
         return FixAndWarnPluginConfig(
             mergedFixPluginConfig as FixPluginConfig,
             mergedWarnPluginConfig as WarnPluginConfig
-        )
+        ).also { it.configLocation = this.configLocation }
     }
 
     override fun validateAndSetDefaults(): PluginConfig {
@@ -48,6 +48,6 @@ data class FixAndWarnPluginConfig(
         return FixAndWarnPluginConfig(
             fix.validateAndSetDefaults(),
             warn.validateAndSetDefaults()
-        )
+        ).also { it.configLocation = this.configLocation }
     }
 }

--- a/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fixandwarn/FixAndWarnPluginConfig.kt
+++ b/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fixandwarn/FixAndWarnPluginConfig.kt
@@ -36,19 +36,18 @@ data class FixAndWarnPluginConfig(
     }
 
     override fun validateAndSetDefaults(): PluginConfig {
-        val fixPluginConfig = fix.validateAndSetDefaults()
-        val warnPluginConfig = warn.validateAndSetDefaults()
-        require(fixPluginConfig.resourceNameTest == warnPluginConfig.testNameSuffix &&
-                fixPluginConfig.batchSize == warnPluginConfig.batchSize
+        require(fix.resourceNameTest == warn.testNameSuffix &&
+                fix.batchSize == warn.batchSize
         ) {
             """
                Test files suffix names and batch sizes should be identical for [fix] and [warn] plugins.
-               But found [fix]: {${fixPluginConfig.resourceNameTest}, ${fixPluginConfig.batchSize}},
-                         [warn]: {${warnPluginConfig.testNameSuffix}, ${warnPluginConfig.batchSize}}
+               But found [fix]: {${fix.resourceNameTest}, ${fix.batchSize}},
+                         [warn]: {${warn.testNameSuffix}, ${warn.batchSize}}
            """
         }
         return FixAndWarnPluginConfig(
-            fixPluginConfig, warnPluginConfig
+            fix.validateAndSetDefaults(),
+            warn.validateAndSetDefaults()
         )
     }
 }

--- a/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fixandwarn/FixAndWarnPluginConfig.kt
+++ b/save-plugins/fix-and-warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fixandwarn/FixAndWarnPluginConfig.kt
@@ -36,7 +36,7 @@ data class FixAndWarnPluginConfig(
     }
 
     override fun validateAndSetDefaults(): PluginConfig {
-        require(fix.resourceNameTest == warn.testNameSuffix &&
+        require(fix.resourceNameTest == warn.testName &&
                 fix.batchSize == warn.batchSize
         ) {
             """

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPlugin.kt
@@ -51,6 +51,7 @@ class FixPlugin(
 
     @Suppress("TOO_LONG_FUNCTION")
     override fun handleFiles(files: Sequence<TestFiles>): Sequence<TestResult> {
+        testConfig.validateAndSetDefaults()
         val fixPluginConfig = testConfig.pluginConfigs.filterIsInstance<FixPluginConfig>().single()
         val generalConfig = testConfig.pluginConfigs.filterIsInstance<GeneralConfig>().single()
         extraFlagsExtractor = ExtraFlagsExtractor(generalConfig, fs)

--- a/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPluginConfig.kt
+++ b/save-plugins/fix-plugin/src/commonMain/kotlin/org/cqfn/save/plugins/fix/FixPluginConfig.kt
@@ -60,7 +60,7 @@ data class FixPluginConfig(
             this.batchSeparator ?: other.batchSeparator,
             this.resourceNameTestSuffix ?: other.resourceNameTestSuffix,
             this.resourceNameExpectedSuffix ?: other.resourceNameExpectedSuffix,
-        )
+        ).also { it.configLocation = this.configLocation }
     }
 
     override fun validateAndSetDefaults() = FixPluginConfig(
@@ -69,5 +69,5 @@ data class FixPluginConfig(
         batchSeparator ?: ", ",
         resourceNameTest,
         resourceNameExpected
-    )
+    ).also { it.configLocation = this.configLocation }
 }

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPlugin.kt
@@ -46,6 +46,7 @@ class WarnPlugin(
     private lateinit var extraFlagsExtractor: ExtraFlagsExtractor
 
     override fun handleFiles(files: Sequence<TestFiles>): Sequence<TestResult> {
+        testConfig.validateAndSetDefaults()
         val warnPluginConfig = testConfig.pluginConfigs.filterIsInstance<WarnPluginConfig>().single()
         val generalConfig = testConfig.pluginConfigs.filterIsInstance<GeneralConfig>().single()
         extraFlagsExtractor = ExtraFlagsExtractor(generalConfig, fs)

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPluginConfig.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPluginConfig.kt
@@ -110,7 +110,7 @@ data class WarnPluginConfig(
             this.linePlaceholder ?: other.linePlaceholder,
             this.wildCardInDirectoryMode ?: other.wildCardInDirectoryMode,
             this.patternForRegexInWarning ?: other.patternForRegexInWarning
-        )
+        ).also { it.configLocation = this.configLocation }
     }
 
     @Suppress(
@@ -164,7 +164,7 @@ data class WarnPluginConfig(
             linePlaceholder ?: "\$line",
             wildCardInDirectoryMode,
             patternForRegexInWarning ?: defaultPatternForRegexInWarning
-        )
+        ).also { it.configLocation = this.configLocation }
     }
 
     private fun requirePositiveIfNotNull(value: Long?) {

--- a/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPluginConfig.kt
+++ b/save-plugins/warn-plugin/src/commonMain/kotlin/org/cqfn/save/plugin/warn/WarnPluginConfig.kt
@@ -71,12 +71,17 @@ data class WarnPluginConfig(
     override var configLocation: Path = "undefined_toml_location".toPath()
 
     /**
+     * suffix name of the test file.
+     */
+    val testName: String = testNameSuffix ?: "Test"
+
+    /**
      * regex for the name of the test files.
      */
-    val resourceNamePattern: Regex = if (testNameSuffix == "Test") {
-        Regex("""(.+)${(testNameSuffix)}\.[\w\d]+""")
+    val resourceNamePattern: Regex = if (testName == "Test") {
+        Regex("""(.+)${(testName)}\.[\w\d]+""")
     } else {
-        Regex("""(.+)${(testNameSuffix)}""")
+        Regex("""(.+)${(testName)}""")
     }
 
     @Suppress("ComplexMethod")
@@ -142,7 +147,7 @@ data class WarnPluginConfig(
             newColumnCaptureGroupOut,
             newMessageCaptureGroupOut,
             exactWarningsMatch ?: true,
-            testNameSuffix ?: "Test",
+            testName,
             linePlaceholder ?: "\$line",
             wildCardInDirectoryMode,
         )


### PR DESCRIPTION
### What's done:
* Restore movement of validation method from https://github.com/cqfn/save/pull/240
* Fix merge and validation methods: update `configLocation`
* Remove redundant `suiteName`'s without test resources
* Make PLAIN as default value for ReportType